### PR TITLE
Remove unsupported python version from actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[Cursor Agent]

Remove Python 3.7 from GitHub Actions workflow to resolve `actions/setup-python@v5` errors on Ubuntu 24.04.