### PR TITLE
Fix GitHub actions for Ubuntu 20.04 deprecation

### DIFF
--- a/.github/workflows/sphinx-to-github-pages.yml
+++ b/.github/workflows/sphinx-to-github-pages.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
[Cursor Agent]

Update GitHub Actions runner to `ubuntu-latest` to avoid issues from the Ubuntu 20.04 retirement.

The `ubuntu-20.04` runner is being deprecated and will be fully unsupported by 2025-04-15, which would cause workflow failures. Using `ubuntu-latest` ensures compatibility and future-proofs the workflow.