### PR TITLE
Update numba cap from <0.47 to >=0.52,<0.61 with improved comments

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,13 +18,38 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Lint with ruff (blocking; same gate as old flake8 E9/F63/F7/F82)
+        run: ruff check . --select=E9,F63,F7,F82
+
+      - name: Lint with ruff (full ruleset from ruff.toml; informational only)
+        run: ruff check . --exit-zero
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # Run once with only the test deps (JIT disabled) and once with Numba
+        # installed (JIT enabled)
+        extras: ["test", "test,fast"]
 
     steps:
       - uses: actions/checkout@v6
@@ -39,21 +64,17 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff pytest pytest-cov
-
       - name: Install package
         run: |
-          pip install -e .[test]
-
-      - name: Lint with ruff
-        run: |
-          ruff check . --select=E9,F63,F7,F82
-          ruff check . --exit-zero
+          python -m pip install --upgrade pip
+          pip install -e ".[${{ matrix.extras }}]"
 
       - name: Test with pytest and generate coverage report
+        # pytest-env sets NUMBA_DISABLE_JIT=1 by default (skip_if_set=true in
+        # pyproject.toml). Set it explicitly here first so pytest-env leaves it alone.
+        # Use 0 when the fast (Numba) extra is installed so JIT is actually exercised.
+        env:
+          NUMBA_DISABLE_JIT: ${{ contains(matrix.extras, 'fast') && '0' || '1' }}
         run: |
           pytest --cov=./ --cov-report=xml
 
@@ -64,5 +85,6 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
+          flags: ${{ contains(matrix.extras, 'fast') && 'numba' || 'no-numba' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,6 +69,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[${{ matrix.extras }}]"
 
+      - name: Verify Numba installation (fast extra)
+        if: contains(matrix.extras, 'fast')
+        run: |
+          python -c "import numba; from elsim.methods import _common; assert _common.numba_enabled; print('numba', numba.__version__)"
+
       - name: Test with pytest and generate coverage report
         run: |
           pytest --cov=./ --cov-report=xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,8 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # Run once with only the test deps (JIT disabled) and once with Numba
-        # installed (JIT enabled)
+        # Run once without Numba (JIT path skipped via ImportError) and once
+        # with Numba installed (JIT path exercised, such as reflected-set usage).
         extras: ["test", "test,fast"]
 
     steps:
@@ -70,11 +70,6 @@ jobs:
           pip install -e ".[${{ matrix.extras }}]"
 
       - name: Test with pytest and generate coverage report
-        # pytest-env sets NUMBA_DISABLE_JIT=1 by default (skip_if_set=true in
-        # pyproject.toml). Set it explicitly here first so pytest-env leaves it alone.
-        # Use 0 when the fast (Numba) extra is installed so JIT is actually exercised.
-        env:
-          NUMBA_DISABLE_JIT: ${{ contains(matrix.extras, 'fast') && '0' || '1' }}
         run: |
           pytest --cov=./ --cov-report=xml
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,20 @@ See [/examples](./examples) folder for more on what it can do, such as reproduct
 
 See [`pyproject.toml`](pyproject.toml).  As of this README, it includes  [`numpy`](https://numpy.org/) and [`scipy`](https://www.scipy.org/) for the simulations, [`tabulate`](https://github.com/astanin/python-tabulate) for printing example tables, [`joblib`](https://joblib.readthedocs.io/en/latest/) for parallelizing extreme examples, and  [`pytest`](https://docs.pytest.org/en/latest/), [`hypothesis`](https://hypothesis.readthedocs.io/en/latest/), and [`pytest-cov`](https://github.com/pytest-dev/pytest-cov) for running the tests.  All should be installable through `conda`.
 
-Optionally, `elsim` can use [`numba`](http://numba.pydata.org/) for speed.  If not available, the code will still run, just more slowly.
+Optionally, `elsim` can use [`numba`](http://numba.pydata.org/) for speed.  Use the `fast` extra when possible. If not available, the code will still run, just more slowly.  (Numba is optional because it does not support every CPU/OS/python combination, and pulls a large LLVM-based stack.)
 
 ## Installation
 
-One possibility is to install with pip:
+From PyPI (recommended — includes Numba):
 
 ```sh
-pip install git+https://github.com/endolith/elsim.git
+pip install elsim[fast]
+```
+
+Core only (no Numba — lighter install, pure Python paths):
+
+```sh
+pip install elsim
 ```
 
 ## Documentation

--- a/elsim/methods/_common.py
+++ b/elsim/methods/_common.py
@@ -9,8 +9,12 @@ import numpy as np
 try:
     from numba import NumbaPendingDeprecationWarning, njit
 
-    # Reflected set will be replaced in numba 0.46 and removed in 0.47.
-    # TODO: Update to support latest numba.
+    # ``irv`` / ``coombs`` pass a Python ``set`` of eliminated candidate IDs into
+    # ``@njit`` helpers; Numba compiles membership tests via reflected ``set`` and
+    # emits ``NumbaPendingDeprecationWarning``. Reflection for ``set`` is officially
+    # deprecated (replacement timeline is not the old 0.47 story—see Numba's
+    # "Deprecation of reflection for List and Set types"). Hide the noise for users;
+    # revisit if a Numba release stops compiling this pattern.
     warnings.simplefilter("ignore", category=NumbaPendingDeprecationWarning)
 
     numba_enabled = True

--- a/elsim/methods/irv.py
+++ b/elsim/methods/irv.py
@@ -86,7 +86,11 @@ def irv(election, tiebreaker=None):
     # votes and can't be distinguished from candidates who never received any.
     _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
     eliminated_cands = set(_all_indices(cand_tallies, 0))
-    _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+    # Guard required: Numba cannot compute the type fingerprint of an empty
+    # Python set (no elements → unknown dtype), so skip the call when there
+    # are no pre-round eliminations.  The call would be a no-op anyway.
+    if eliminated_cands:
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
 
     for round_ in range(n_cands):
         _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ examples = [
     "joblib",
 ]
 fast = [
-    "numba<0.47",
+    # Reflected ``set`` in IRV/Coombs @njit still compiles through current Numba;
+    # cap bumped as new minors are smoke-tested via Dependabot. See ``elsim.methods._common``.
+    "numba>=0.52,<0.61",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
-    "pytest-env",
     "hypothesis",
     "ruff",
 ]
@@ -56,6 +55,3 @@ path = "elsim/__init__.py"
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore=examples --cov --cov-report html --tb=short"
 doctest_optionflags = ["ELLIPSIS"]
-
-[tool.pytest_env]
-NUMBA_DISABLE_JIT = { value = "1", skip_if_set = true }


### PR DESCRIPTION
Supersedes dependabot PR #31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes dependency constraints and tweaks IRV’s elimination pre-pass to avoid a Numba-specific empty-set compilation issue, which could subtly affect behavior in edge cases.
> 
> **Overview**
> **Numba support is updated and better tested.** The `fast` extra now pins Numba to `>=0.52,<0.61`, documentation steers users toward `elsim[fast]`, and `_common.py` suppresses `NumbaPendingDeprecationWarning` for reflected `set` usage.
> 
> **CI is reworked to lint separately and run tests with/without Numba.** GitHub Actions adds a dedicated `ruff` lint job, expands the pytest matrix to run both `test` and `test,fast` installs (verifying Numba when present), and tags Codecov uploads with `numba` vs `no-numba` flags.
> 
> **Minor runtime fix:** `irv` now skips calling the Numba-compiled `_inc_rank_idx` when the initial eliminated set is empty to avoid Numba type-fingerprinting failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf9bc169ede2ac9654810b5d116c4ebd7265aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->