### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pure Python library (no servers, databases, or services). All development tasks run locally via the Python interpreter.
+
+### Key commands
+
+- **Install (dev):** `pip install -e ".[test,examples]"` — installs the package in editable mode with test and example dependencies.
+- **Lint (blocking):** `ruff check --select=E9,F63,F7,F82 .` — the subset enforced by pre-commit (must pass).
+- **Lint (full):** `ruff check .` — full ruleset from `ruff.toml`; informational only (exit-zero in pre-commit).
+- **Test:** `pytest` — runs all unit tests + doctests with coverage (options configured in `pyproject.toml`).
+- **Examples:** `python examples/<script>.py` — run any example script (requires `tabulate`, `joblib` from `examples` extra).
+
+### Caveats
+
+- Numba (`[fast]` extra) is not installed in the Cloud VM. The library works without it — you will see a `UserWarning: Numba not installed, Condorcet code will run slower` warning at import time. This is expected and harmless.
+- `~/.local/bin` must be on `PATH` for `pytest` and `ruff` to be found (the update script installs to user site-packages).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working in this repository.

### What's included

- Key commands for installing, linting, testing, and running examples
- Caveat that Numba is not installed in the Cloud VM (library works without it)
- Note about `~/.local/bin` PATH requirement for `pytest` and `ruff`

### Verification

All checks pass in the cloud environment:

- **Lint (blocking):** `ruff check --select=E9,F63,F7,F82 .` — All checks passed
- **Tests:** `pytest --doctest-modules --ignore=examples --cov` — 215/215 passed
- **Example script:** `python examples/weber_1977_expressions.py` — reproduces Weber 1977 table correctly
- **Hello-world demo:** ran multiple voting methods (Black, FPTP, Borda, IRV) on both fixed and random elections

Test output:
[pytest_output.log](https://cursor.com/agents/bc-ad2333fb-26d5-469c-bb02-7f1542bea599/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpytest_output.log)

Hello world output:
[hello_world_output.log](https://cursor.com/agents/bc-ad2333fb-26d5-469c-bb02-7f1542bea599/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad2333fb-26d5-469c-bb02-7f1542bea599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad2333fb-26d5-469c-bb02-7f1542bea599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

