### PR TITLE
Add approval+runoff and blanket primary variants (issue #17)

### DIFF
--- a/elsim/methods/__init__.py
+++ b/elsim/methods/__init__.py
@@ -6,8 +6,7 @@ according to the rules of that method.
 """
 from elsim.methods.approval import approval, combined_approval
 from elsim.methods.black import black
-from elsim.methods.blanket_primary import (approval_runoff, irv_eliminate_to_n,
-                                           irv_primary_top_n_irv,
+from elsim.methods.blanket_primary import (approval_runoff,
                                            irv_primary_top_n_runoff,
                                            top_five_condorcet, top_five_irv,
                                            top_five_runoff, top_four_condorcet,
@@ -36,8 +35,6 @@ __all__ = [
     'coombs',
     'fptp',
     'irv',
-    'irv_eliminate_to_n',
-    'irv_primary_top_n_irv',
     'irv_primary_top_n_runoff',
     'matrix_from_scores',
     'ranked_election_to_matrix',

--- a/elsim/methods/__init__.py
+++ b/elsim/methods/__init__.py
@@ -4,25 +4,20 @@ Implements various election methods.
 These take collections of ballots (elections) as inputs and return the winner
 according to the rules of that method.
 """
-from elsim.methods.approval import approval, combined_approval
-from elsim.methods.black import black
-from elsim.methods.blanket_primary import (approval_runoff,
-                                           irv_primary_top_n_runoff,
-                                           top_five_condorcet, top_five_irv,
-                                           top_five_runoff, top_four_condorcet,
-                                           top_four_irv, top_four_runoff,
-                                           top_n_condorcet, top_n_irv,
-                                           top_n_runoff)
-from elsim.methods.borda import borda
-from elsim.methods.condorcet import (condorcet, condorcet_from_matrix,
-                                     ranked_election_to_matrix)
-from elsim.methods.coombs import coombs
-from elsim.methods.fptp import fptp, sntv
-from elsim.methods.irv import irv
-from elsim.methods.runoff import runoff
-from elsim.methods.score import score
-from elsim.methods.star import matrix_from_scores, star
-from elsim.methods.utility_winner import utility_winner
+from .approval import approval, combined_approval
+from .black import black
+from .blanket_primary import (approval_runoff, irv_primary_top_n_runoff,
+                             top_n_condorcet, top_n_irv, top_n_runoff)
+from .borda import borda
+from .condorcet import (condorcet, condorcet_from_matrix,
+                        ranked_election_to_matrix)
+from .coombs import coombs
+from .fptp import fptp, sntv
+from .irv import irv
+from .runoff import runoff
+from .score import score
+from .star import matrix_from_scores, star
+from .utility_winner import utility_winner
 
 __all__ = [
     'approval',
@@ -42,12 +37,6 @@ __all__ = [
     'sntv',
     'score',
     'star',
-    'top_five_condorcet',
-    'top_five_irv',
-    'top_five_runoff',
-    'top_four_condorcet',
-    'top_four_irv',
-    'top_four_runoff',
     'top_n_condorcet',
     'top_n_irv',
     'top_n_runoff',

--- a/elsim/methods/__init__.py
+++ b/elsim/methods/__init__.py
@@ -6,6 +6,14 @@ according to the rules of that method.
 """
 from elsim.methods.approval import approval, combined_approval
 from elsim.methods.black import black
+from elsim.methods.blanket_primary import (approval_runoff, irv_eliminate_to_n,
+                                           irv_primary_top_n_irv,
+                                           irv_primary_top_n_runoff,
+                                           top_five_condorcet, top_five_irv,
+                                           top_five_runoff, top_four_condorcet,
+                                           top_four_irv, top_four_runoff,
+                                           top_n_condorcet, top_n_irv,
+                                           top_n_runoff)
 from elsim.methods.borda import borda
 from elsim.methods.condorcet import (condorcet, condorcet_from_matrix,
                                      ranked_election_to_matrix)
@@ -19,6 +27,7 @@ from elsim.methods.utility_winner import utility_winner
 
 __all__ = [
     'approval',
+    'approval_runoff',
     'black',
     'borda',
     'combined_approval',
@@ -27,11 +36,23 @@ __all__ = [
     'coombs',
     'fptp',
     'irv',
+    'irv_eliminate_to_n',
+    'irv_primary_top_n_irv',
+    'irv_primary_top_n_runoff',
     'matrix_from_scores',
     'ranked_election_to_matrix',
     'runoff',
     'sntv',
     'score',
     'star',
+    'top_five_condorcet',
+    'top_five_irv',
+    'top_five_runoff',
+    'top_four_condorcet',
+    'top_four_irv',
+    'top_four_runoff',
+    'top_n_condorcet',
+    'top_n_irv',
+    'top_n_runoff',
     'utility_winner',
 ]

--- a/elsim/methods/__init__.py
+++ b/elsim/methods/__init__.py
@@ -7,7 +7,7 @@ according to the rules of that method.
 from .approval import approval, combined_approval
 from .black import black
 from .blanket_primary import (approval_runoff, irv_primary_top_n_runoff,
-                             top_n_condorcet, top_n_irv, top_n_runoff)
+                              top_n_condorcet, top_n_irv, top_n_runoff)
 from .borda import borda
 from .condorcet import (condorcet, condorcet_from_matrix,
                         ranked_election_to_matrix)

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -61,8 +61,6 @@ def _top_n_from_plurality_tallies(tallies, n, tiebreaker):
 
 def _primary_top_n_approval(approval_election, n, tiebreaker):
     approval_election = np.asarray(approval_election, dtype=np.uint8)
-    if approval_election.min() < 0 or approval_election.max() > 1:
-        raise ValueError('Approval ballots must contain only 0 and 1')
     tallies = approval_election.sum(axis=0)
     n_cands = approval_election.shape[1]
     if n >= n_cands:
@@ -154,8 +152,6 @@ def irv_eliminate_to_n(election, n, tiebreaker=None):
 
     while n_cands - len(eliminated_cands) > n:
         _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
-        if n_cands - len(eliminated_cands) <= n:
-            break
         cand_tallies_list = cand_tallies.tolist()
         active_tallies = [cand_tallies_list[c] for c in range(n_cands)
                           if c not in eliminated_cands]
@@ -212,7 +208,7 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     if approval_election.shape[0] != ranked_election.shape[0]:
         raise ValueError('approval_election and ranked_election must have the '
                          'same number of rows (voters)')
-    if approval_election.min() < 0 or approval_election.max() > 1:
+    if approval_election.max() > 1:
         raise ValueError('Approval ballots must contain only 0 and 1')
 
     finalists = _primary_top_n_approval(approval_election, 2, tiebreaker)

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -1,0 +1,439 @@
+"""
+Two-round systems with a primary that narrows the field (blanket / top-n).
+
+These model nonpartisan blanket primaries and related reforms: approval plus
+runoff (unified primary), pick-one top-four or top-five with a ranked general
+(Final Four / Final Five), IRV-style primaries that leave a fixed slate, and
+Condorcet in the general per :wikipedia:`Top-four primary` variations.
+"""
+import numpy as np
+
+from elsim.methods._common import (_all_indices, _get_tiebreak, _inc_rank_idx,
+                                   _no_tiebreak, _order_tiebreak_elim,
+                                   _order_tiebreak_keep, _random_tiebreak,
+                                   _tally_at_rank_idx)
+from elsim.methods.condorcet import condorcet
+from elsim.methods.fptp import sntv
+from elsim.methods.irv import irv
+from elsim.methods.runoff import runoff
+
+_tiebreak_map_keep = {'order': _order_tiebreak_keep,
+                      'random': _random_tiebreak,
+                      None: _no_tiebreak}
+
+_tiebreak_map_elim = {'order': _order_tiebreak_elim,
+                      'random': _random_tiebreak,
+                      None: _no_tiebreak}
+
+
+def _top_n_from_plurality_tallies(tallies, n, tiebreaker):
+    """
+    Candidate indices with the top ``n`` first-preference counts, breaking
+    boundary ties the same way as ``sntv``.
+    """
+    tallies = np.asarray(tallies)
+    n_cands = len(tallies)
+    if n < 1:
+        raise ValueError('n must be at least 1')
+    if n >= n_cands:
+        return set(range(n_cands))
+
+    sorted_indices = np.argsort(tallies)
+    top_candidates = sorted_indices[-n:]
+    worst_top = top_candidates[0]
+    best_not_top = sorted_indices[-n - 1]
+
+    if tallies[worst_top] == tallies[best_not_top]:
+        untied_winners = sorted_indices[tallies[sorted_indices] >
+                                        tallies[worst_top]]
+        tied_candidates = np.where(tallies == tallies[worst_top])[0]
+        tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map_keep)
+        n_needed = n - len(untied_winners)
+        tie_winners = tiebreak(list(tied_candidates), n_needed)
+        if tie_winners == [None]:
+            return None
+        winners = set(untied_winners) | set(tie_winners)
+    else:
+        winners = set(top_candidates)
+
+    return set(int(w) for w in winners)
+
+
+def _primary_top_n_approval(approval_election, n, tiebreaker):
+    approval_election = np.asarray(approval_election, dtype=np.uint8)
+    if approval_election.min() < 0 or approval_election.max() > 1:
+        raise ValueError('Approval ballots must contain only 0 and 1')
+    tallies = approval_election.sum(axis=0)
+    n_cands = approval_election.shape[1]
+    if n >= n_cands:
+        return set(range(n_cands))
+    return _top_n_from_plurality_tallies(tallies, n, tiebreaker)
+
+
+def _restrict_ballots(election, allowed):
+    """Drop non-finalists from each ballot, preserving order (local IDs 0..k-1)."""
+    election = np.asarray(election)
+    allowed_sorted = sorted(allowed)
+    old_to_new = {cand: j for j, cand in enumerate(allowed_sorted)}
+    new_to_old = {j: cand for j, cand in enumerate(allowed_sorted)}
+    rows = []
+    for ballot in election:
+        row = [old_to_new[c] for c in ballot.tolist() if c in old_to_new]
+        rows.append(row)
+    return np.asarray(rows, dtype=election.dtype), new_to_old
+
+
+def _head_to_head_two(finalist_0, finalist_1, election, tiebreaker):
+    """Pairwise winner between two finalists using full rankings (contingent vote)."""
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map_keep)
+    n_voters = election.shape[0]
+    finalist_0_tally = 0
+    finalist_1_tally = 0
+    for ballot in election:
+        ballot_list = ballot.tolist()
+        if ballot_list.index(finalist_0) < ballot_list.index(finalist_1):
+            finalist_0_tally += 1
+        else:
+            finalist_1_tally += 1
+    assert finalist_0_tally + finalist_1_tally == n_voters
+    if finalist_0_tally == finalist_1_tally:
+        return tiebreak([finalist_0, finalist_1])[0]
+    if finalist_0_tally > finalist_1_tally:
+        return finalist_0
+    return finalist_1
+
+
+def irv_eliminate_to_n(election, n, tiebreaker=None):
+    """
+    Sequential-elimination primary: repeatedly eliminate the IRV last-place
+    candidate among remaining candidates until ``n`` (or fewer) remain.
+
+    This is the ranked primary used in some top-four reform variants. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots (same format as ``irv``).
+    n : int
+        Number of candidates that should remain.
+    tiebreaker : {'random', 'order', None}, optional
+        Same meaning as in ``irv`` (who to eliminate when last-place is tied).
+
+    Returns
+    -------
+    finalists : {set of int, None}
+        Candidate IDs still in the race, or ``None`` if a tie could not be
+        broken while eliminating.
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary#Variations`
+
+    Examples
+    --------
+    >>> election = [[0, 1, 2], [1, 2, 0], [2, 0, 1]]
+    >>> sorted(irv_eliminate_to_n(election, 2, tiebreaker='order'))
+    [0, 1]
+    """
+    election = np.asarray(election)
+    n_voters, n_cands = election.shape
+    if n < 1:
+        raise ValueError('n must be at least 1')
+    if n >= n_cands:
+        return set(range(n_cands))
+
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map_elim)
+
+    voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
+    cand_tallies = np.empty(n_cands, dtype=np.uint)
+
+    _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+    eliminated_cands = set(_all_indices(cand_tallies.tolist(), 0))
+    if eliminated_cands:
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+
+    while n_cands - len(eliminated_cands) > n:
+        _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+        if n_cands - len(eliminated_cands) <= n:
+            break
+        cand_tallies_list = cand_tallies.tolist()
+        active_tallies = [cand_tallies_list[c] for c in range(n_cands)
+                          if c not in eliminated_cands]
+        last_place_tally = min(active_tallies)
+        last_place_cands = [c for c in range(n_cands)
+                            if c not in eliminated_cands
+                            and cand_tallies_list[c] == last_place_tally]
+        cand_to_eliminate = tiebreak(last_place_cands)[0]
+        if cand_to_eliminate is None:
+            return None
+        eliminated_cands.add(cand_to_eliminate)
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+
+    return {c for c in range(n_cands) if c not in eliminated_cands}
+
+
+def approval_runoff(approval_election, ranked_election, tiebreaker=None):
+    """
+    Unified primary / top-two approval plus runoff (St. Louis style). [1]_
+
+    The two candidates with the most approvals advance; the winner is decided
+    by pairwise majority on the ranked ballots (contingent vote between the
+    two finalists), the usual ranked-ballot model when the general uses a
+    separate runoff.
+
+    Parameters
+    ----------
+    approval_election : array_like
+        Approval ballots: rows are voters, columns candidates, entries 0/1.
+    ranked_election : array_like
+        Complete ranked ballots for the same voters (same number of rows as
+        ``approval_election``).
+    tiebreaker : {'random', 'order', None}, optional
+        Used for selecting primary finalists and for a tied general.
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Unified primary`
+
+    Examples
+    --------
+    >>> A, B, C = 0, 1, 2
+    >>> approvals = [[1, 1, 0], [1, 1, 0], [0, 1, 1]]
+    >>> ranked = [[B, A, C], [B, C, A], [C, B, A]]
+    >>> approval_runoff(approvals, ranked)
+    1
+    """
+    approval_election = np.asarray(approval_election, dtype=np.uint8)
+    ranked_election = np.asarray(ranked_election)
+    if approval_election.shape[0] != ranked_election.shape[0]:
+        raise ValueError('approval_election and ranked_election must have the '
+                         'same number of rows (voters)')
+    if approval_election.min() < 0 or approval_election.max() > 1:
+        raise ValueError('Approval ballots must contain only 0 and 1')
+
+    finalists = _primary_top_n_approval(approval_election, 2, tiebreaker)
+    if finalists is None:
+        return None
+    if len(finalists) == 1:
+        (only,) = tuple(finalists)
+        return only
+    finalist_0, finalist_1 = sorted(finalists)
+    out = _head_to_head_two(finalist_0, finalist_1, ranked_election,
+                            tiebreaker)
+    return int(out) if out is not None else None
+
+
+def top_n_irv(election, n, tiebreaker=None):
+    """
+    Pick-one top-``n`` primary (plurality / SNTV) and an IRV general. [1]_
+
+    The ``n`` candidates with the most first-preference votes advance; the
+    winner is chosen by instant-runoff on the same rankings restricted to
+    those finalists (Alaska-style Final Four when ``n`` is 4).
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots.
+    n : int
+        Primary cutoff (4 for Final Four, 5 for Final Five).
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary`
+
+    Examples
+    --------
+    >>> A, B, C = 0, 1, 2
+    >>> election = [*6*[[A, B, C]], *3*[[B, A, C]], *1*[[C, B, A]]]
+    >>> top_n_irv(election, 2)
+    0
+    """
+    finalists = sntv(election, n, tiebreaker)
+    if finalists is None:
+        return None
+    sub, new_to_old = _restrict_ballots(election, finalists)
+    w = irv(sub, tiebreaker)
+    if w is None:
+        return None
+    return int(new_to_old[w])
+
+
+def top_n_runoff(election, n, tiebreaker=None):
+    """
+    Pick-one top-``n`` primary and a top-two contingent general. [1]_
+
+    After the top ``n`` candidates by plurality advance, the general election
+    applies the same two-candidate contingent logic as ``runoff`` on the
+    restricted set (first round among finalists only, then pairwise between the
+    top two by first preference among finalists).
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots.
+    n : int
+        Primary cutoff.
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary#Variations`
+
+    Examples
+    --------
+    >>> A, B, C, D = 0, 1, 2, 3
+    >>> election = [*3*[[A, B, C, D]], *2*[[B, A, C, D]], *1*[[C, D, A, B]]]
+    >>> isinstance(top_n_runoff(election, 4), int)
+    True
+    """
+    finalists = sntv(election, n, tiebreaker)
+    if finalists is None:
+        return None
+    sub, new_to_old = _restrict_ballots(election, finalists)
+    w = runoff(sub, tiebreaker)
+    if w is None:
+        return None
+    return int(new_to_old[w])
+
+
+def top_n_condorcet(election, n, tiebreaker=None):
+    """
+    Pick-one top-``n`` primary and a Condorcet pairwise general. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots.
+    n : int
+        Primary cutoff.
+    tiebreaker : {'random', 'order', None}, optional
+        Used only for the primary; the general has no tiebreaker (same as
+        ``condorcet``).
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary#Variations`
+
+    Examples
+    --------
+    >>> A, B, C = 0, 1, 2
+    >>> election = [[A, B, C], [A, B, C], [B, A, C]]
+    >>> top_n_condorcet(election, 2)
+    0
+    """
+    finalists = sntv(election, n, tiebreaker)
+    if finalists is None:
+        return None
+    sub, new_to_old = _restrict_ballots(election, finalists)
+    w = condorcet(sub)
+    if w is None:
+        return None
+    return int(new_to_old[w])
+
+
+def irv_primary_top_n_irv(election, n, tiebreaker=None):
+    """
+    Ranked IRV-style primary until ``n`` candidates remain, then IRV general. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots.
+    n : int
+        Target number of finalists after the primary.
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary#Variations`
+    """
+    finalists = irv_eliminate_to_n(election, n, tiebreaker)
+    if finalists is None:
+        return None
+    sub, new_to_old = _restrict_ballots(election, finalists)
+    w = irv(sub, tiebreaker)
+    if w is None:
+        return None
+    return int(new_to_old[w])
+
+
+def irv_primary_top_n_runoff(election, n, tiebreaker=None):
+    """
+    IRV-style primary until ``n`` remain, then top-two contingent general. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Ranked ballots.
+    n : int
+        Target number of finalists after the primary.
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] :wikipedia:`Top-four primary#Variations`
+    """
+    finalists = irv_eliminate_to_n(election, n, tiebreaker)
+    if finalists is None:
+        return None
+    sub, new_to_old = _restrict_ballots(election, finalists)
+    w = runoff(sub, tiebreaker)
+    if w is None:
+        return None
+    return int(new_to_old[w])
+
+
+def top_four_irv(election, tiebreaker=None):
+    """Same as ``top_n_irv(election, 4, tiebreaker)``."""
+    return top_n_irv(election, 4, tiebreaker)
+
+
+def top_five_irv(election, tiebreaker=None):
+    """Same as ``top_n_irv(election, 5, tiebreaker)``."""
+    return top_n_irv(election, 5, tiebreaker)
+
+
+def top_four_runoff(election, tiebreaker=None):
+    """Same as ``top_n_runoff(election, 4, tiebreaker)``."""
+    return top_n_runoff(election, 4, tiebreaker)
+
+
+def top_five_runoff(election, tiebreaker=None):
+    """Same as ``top_n_runoff(election, 5, tiebreaker)``."""
+    return top_n_runoff(election, 5, tiebreaker)
+
+
+def top_four_condorcet(election, tiebreaker=None):
+    """Same as ``top_n_condorcet(election, 4, tiebreaker)``."""
+    return top_n_condorcet(election, 4, tiebreaker)
+
+
+def top_five_condorcet(election, tiebreaker=None):
+    """Same as ``top_n_condorcet(election, 5, tiebreaker)``."""
+    return top_n_condorcet(election, 5, tiebreaker)

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -5,8 +5,10 @@ general election.
 These implement nonpartisan blanket primaries and related reforms: approval
 plus runoff (unified primary), pick-one top-four or top-five with a ranked
 general (Final Four / Final Five), IRV-style primaries that leave a fixed
-slate, and Condorcet in the general; see the ``References`` sections of the
-individual functions for sources.
+slate, and Condorcet in the general.  Each public function's docstring cites
+encyclopedia summaries where helpful and, where available, primary sources
+(peer-reviewed definitions, founding monographs, official election-administration
+pages, or reform white papers).
 """
 import numpy as np
 
@@ -111,7 +113,8 @@ def irv_eliminate_to_n(election, n, tiebreaker=None):
     The candidate with the fewest first-preference votes among those still in
     the race is eliminated (same rule as ``irv``), and the process repeats until
     at most ``n`` candidates remain.  This models the ranked primary described
-    in reform proposals for top-four systems. [1]_
+    in reform proposals for top-four systems. [1]_  FairVote circulated model
+    policy language for top-four and related reforms. [2]_
 
     Parameters
     ----------
@@ -135,6 +138,7 @@ def irv_eliminate_to_n(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
 
     Examples
     --------
@@ -185,7 +189,11 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     The two candidates with the most approvals advance.  The general election
     is modeled as a pairwise majority vote between those two on the ranked
     ballots (the contingent vote, same ranked-ballot abstraction as ``runoff``
-    uses between its finalists). [1]_ [2]_
+    uses between its finalists). [1]_ [2]_  Delemazure et al. define and study
+    the approval-with-runoff family in the computational social choice literature. [3]_
+    St. Louis voters adopted this pattern for municipal offices in 2020; the
+    city's election materials illustrate the approve-many primary and two-candidate
+    runoff. [4]_
 
     Parameters
     ----------
@@ -209,6 +217,8 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     ----------
     .. [1] `Unified primary <https://en.wikipedia.org/wiki/Unified_primary>`__
     .. [2] `Contingent vote <https://en.wikipedia.org/wiki/Contingent_vote>`__
+    .. [3] `Delemazure et al., "Approval with Runoff" (IJCAI 2022) <https://doi.org/10.24963/ijcai.2022/33>`__
+    .. [4] `City of St. Louis, sample general-election ballot (Nov. 2020, PDF) <https://www.stlouis-mo.gov/government/departments/board-election-commissioners/documents/upload/Nov20-Final-All-Races-Sample-Ballot-9-9-20-1.pdf>`__
 
     Examples
     --------
@@ -246,7 +256,10 @@ def top_n_irv(election, n, tiebreaker=None):
     The ``n`` candidates with the most first-preference votes advance (same
     rule as ``sntv``).  The winner is then chosen by ``irv`` on the same
     rankings restricted to those finalists (as used in Alaska-style top-four
-    with an IRV general). [1]_
+    with an IRV general). [1]_  Alaska's Division of Elections describes the
+    nonpartisan top-four primary and ranked-choice general in official voter
+    materials. [2]_  FairVote published an early top-four policy guide with
+    model legislative language. [3]_
 
     Parameters
     ----------
@@ -271,6 +284,8 @@ def top_n_irv(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [3] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
 
     Examples
     --------
@@ -298,6 +313,10 @@ def top_n_runoff(election, n, tiebreaker=None):
     uses the same two-candidate contingent logic as ``runoff`` on the
     restricted set of finalists (first round among finalists only, then
     pairwise between the top two by first preference among finalists). [1]_
+    Alaska's Division of Elections documents the combined top-four primary and
+    ranked general election. [2]_  The Electoral Reform Society describes the
+    contingent / supplementary vote as the two-stage reduction to a pairwise
+    majority choice. [3]_
 
     Parameters
     ----------
@@ -320,6 +339,8 @@ def top_n_runoff(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
 
     Examples
     --------
@@ -345,7 +366,9 @@ def top_n_condorcet(election, n, tiebreaker=None):
 
     The primary uses the same top-``n`` rule as ``sntv``.  The general election
     applies ``condorcet`` to the restricted rankings (no tiebreaker in the
-    general, matching ``condorcet`` itself). [1]_ [2]_
+    general, matching ``condorcet`` itself). [1]_  Condorcet's 1785 essay is the
+    classical source for pairwise majority comparisons. [2]_  See also the
+    encyclopedia overview of Condorcet methods. [3]_
 
     Parameters
     ----------
@@ -369,7 +392,8 @@ def top_n_condorcet(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
+    .. [2] `Condorcet (1785), *Essai sur l'application de l'analyse à la probabilité des décisions rendues à la pluralité des voix* (BnF Gallica) <https://gallica.bnf.fr/ark:/12148/bpt6k417181>`__
+    .. [3] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
 
     Examples
     --------
@@ -394,7 +418,9 @@ def irv_primary_top_n_irv(election, n, tiebreaker=None):
     ``n``, then an IRV general.
 
     The primary is ``irv_eliminate_to_n``; the general is ``irv`` on ballots
-    restricted to the surviving finalists. [1]_
+    restricted to the surviving finalists. [1]_  Hare's treatise is a
+    foundational English-language source for transferable-vote elimination
+    rules of the kind ``irv`` implements. [2]_
 
     Parameters
     ----------
@@ -417,6 +443,7 @@ def irv_primary_top_n_irv(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Hare (1859), *A Treatise on the Election of Representatives, Parliamentary and Municipal* (Internet Archive) <https://archive.org/details/atreatiseonelec01haregoog>`__
 
     Examples
     --------
@@ -441,7 +468,9 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     ``n``, then a top-two contingent general.
 
     The primary is ``irv_eliminate_to_n``; the general is ``runoff`` on
-    ballots restricted to the surviving finalists. [1]_
+    ballots restricted to the surviving finalists. [1]_  Alaska's Division of
+    Elections describes the top-four primary with a ranked general election,
+    which matches the same two-stage structure at ``n`` = 4. [2]_
 
     Parameters
     ----------
@@ -464,6 +493,7 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
 
     Examples
     --------
@@ -487,7 +517,7 @@ def top_four_irv(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-four primary and an
     IRV general.
 
-    Same as ``top_n_irv(election, 4, tiebreaker)``. [1]_
+    Same as ``top_n_irv(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -504,6 +534,8 @@ def top_four_irv(election, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [3] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
     """
     return top_n_irv(election, 4, tiebreaker)
 
@@ -513,7 +545,9 @@ def top_five_irv(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-five primary and an
     IRV general.
 
-    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_
+    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_  Gehl and
+    Porter's report is a widely cited business-school source for the "Final
+    Five" reform packaging. [3]_
 
     Parameters
     ----------
@@ -531,6 +565,7 @@ def top_five_irv(election, tiebreaker=None):
     ----------
     .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
     .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    .. [3] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
     """
     return top_n_irv(election, 5, tiebreaker)
 
@@ -540,7 +575,7 @@ def top_four_runoff(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-four primary and a
     top-two contingent general.
 
-    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_
+    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -556,7 +591,9 @@ def top_four_runoff(election, tiebreaker=None):
 
     References
     ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
     """
     return top_n_runoff(election, 4, tiebreaker)
 
@@ -566,7 +603,7 @@ def top_five_runoff(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-five primary and a
     top-two contingent general.
 
-    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_
+    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_ [5]_
 
     Parameters
     ----------
@@ -582,8 +619,11 @@ def top_five_runoff(election, tiebreaker=None):
 
     References
     ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
     .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    .. [3] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [4] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
+    .. [5] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
     """
     return top_n_runoff(election, 5, tiebreaker)
 
@@ -593,7 +633,7 @@ def top_four_condorcet(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-four primary and a
     Condorcet pairwise general.
 
-    Same as ``top_n_condorcet(election, 4, tiebreaker)``. [1]_
+    Same as ``top_n_condorcet(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -609,7 +649,9 @@ def top_four_condorcet(election, tiebreaker=None):
 
     References
     ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Condorcet (1785), *Essai sur l'application de l'analyse à la probabilité des décisions rendues à la pluralité des voix* (BnF Gallica) <https://gallica.bnf.fr/ark:/12148/bpt6k417181>`__
+    .. [3] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
     """
     return top_n_condorcet(election, 4, tiebreaker)
 
@@ -619,7 +661,7 @@ def top_five_condorcet(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-five primary and a
     Condorcet pairwise general.
 
-    Same as ``top_n_condorcet(election, 5, tiebreaker)``. [1]_ [2]_
+    Same as ``top_n_condorcet(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_ [5]_
 
     Parameters
     ----------
@@ -635,7 +677,10 @@ def top_five_condorcet(election, tiebreaker=None):
 
     References
     ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
     .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    .. [3] `Condorcet (1785), *Essai sur l'application de l'analyse à la probabilité des décisions rendues à la pluralité des voix* (BnF Gallica) <https://gallica.bnf.fr/ark:/12148/bpt6k417181>`__
+    .. [4] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
+    .. [5] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
     """
     return top_n_condorcet(election, 5, tiebreaker)

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -1,10 +1,12 @@
 """
-Two-round systems with a primary that narrows the field (blanket / top-n).
+Two-round voting methods that combine a primary (narrowing the field) with a
+general election.
 
-These model nonpartisan blanket primaries and related reforms: approval plus
-runoff (unified primary), pick-one top-four or top-five with a ranked general
-(Final Four / Final Five), IRV-style primaries that leave a fixed slate, and
-Condorcet in the general per :wikipedia:`Top-four primary` variations.
+These implement nonpartisan blanket primaries and related reforms: approval
+plus runoff (unified primary), pick-one top-four or top-five with a ranked
+general (Final Four / Final Five), IRV-style primaries that leave a fixed
+slate, and Condorcet in the general; see the ``References`` sections of the
+individual functions for sources.
 """
 import numpy as np
 
@@ -103,29 +105,36 @@ def _head_to_head_two(finalist_0, finalist_1, election, tiebreaker):
 
 def irv_eliminate_to_n(election, n, tiebreaker=None):
     """
-    Sequential-elimination primary: repeatedly eliminate the IRV last-place
-    candidate among remaining candidates until ``n`` (or fewer) remain.
+    Find the remaining candidates after an IRV-style sequential elimination
+    primary.
 
-    This is the ranked primary used in some top-four reform variants. [1]_
+    The candidate with the fewest first-preference votes among those still in
+    the race is eliminated (same rule as ``irv``), and the process repeats until
+    at most ``n`` candidates remain.  This models the ranked primary described
+    in reform proposals for top-four systems. [1]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots (same format as ``irv``).
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
-        Number of candidates that should remain.
+        Number of candidates that should remain when the primary ends.
     tiebreaker : {'random', 'order', None}, optional
-        Same meaning as in ``irv`` (who to eliminate when last-place is tied).
+        If there is a tie, and `tiebreaker` is ``'random'``, tied candidates
+        are eliminated or selected at random.
+        If 'order', the lowest-ID tied candidate is preferred in each tie.
+        By default, ``None`` is returned if there are any ties.
 
     Returns
     -------
     finalists : {set of int, None}
-        Candidate IDs still in the race, or ``None`` if a tie could not be
-        broken while eliminating.
+        The set of candidate IDs still in the race, or ``None`` for an
+        unbroken tie during elimination.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary#Variations`
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
 
     Examples
     --------
@@ -170,30 +179,36 @@ def irv_eliminate_to_n(election, n, tiebreaker=None):
 
 def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     """
-    Unified primary / top-two approval plus runoff (St. Louis style). [1]_
+    Find the winner of an election using a top-two approval primary and a
+    pairwise runoff on ranked ballots.
 
-    The two candidates with the most approvals advance; the winner is decided
-    by pairwise majority on the ranked ballots (contingent vote between the
-    two finalists), the usual ranked-ballot model when the general uses a
-    separate runoff.
+    The two candidates with the most approvals advance.  The general election
+    is modeled as a pairwise majority vote between those two on the ranked
+    ballots (the contingent vote, same ranked-ballot abstraction as ``runoff``
+    uses between its finalists). [1]_ [2]_
 
     Parameters
     ----------
     approval_election : array_like
-        Approval ballots: rows are voters, columns candidates, entries 0/1.
+        A 2D collection of approval ballots.  See `approval` for format.
     ranked_election : array_like
-        Complete ranked ballots for the same voters (same number of rows as
-        ``approval_election``).
+        A collection of ranked ballots for the same voters as
+        ``approval_election`` (same number of rows).  See `borda` for format.
     tiebreaker : {'random', 'order', None}, optional
-        Used for selecting primary finalists and for a tied general.
+        If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
+        is returned in the primary or in a tied general.
+        If 'order', the lowest-ID tied candidate is returned.
+        By default, ``None`` is returned for ties.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
 
     References
     ----------
-    .. [1] :wikipedia:`Unified primary`
+    .. [1] `Unified primary <https://en.wikipedia.org/wiki/Unified_primary>`__
+    .. [2] `Contingent vote <https://en.wikipedia.org/wiki/Contingent_vote>`__
 
     Examples
     --------
@@ -225,27 +240,37 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
 
 def top_n_irv(election, n, tiebreaker=None):
     """
-    Pick-one top-``n`` primary (plurality / SNTV) and an IRV general. [1]_
+    Find the winner of an election using a pick-one top-``n`` primary and an
+    IRV general.
 
-    The ``n`` candidates with the most first-preference votes advance; the
-    winner is chosen by instant-runoff on the same rankings restricted to
-    those finalists (Alaska-style Final Four when ``n`` is 4).
+    The ``n`` candidates with the most first-preference votes advance (same
+    rule as ``sntv``).  The winner is then chosen by ``irv`` on the same
+    rankings restricted to those finalists (as used in Alaska-style top-four
+    with an IRV general). [1]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots.
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
-        Primary cutoff (4 for Final Four, 5 for Final Five).
+        Number of candidates who advance from the primary (4 for Final Four,
+        5 for Final Five).
     tiebreaker : {'random', 'order', None}, optional
+        If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
+        is returned or tied candidates are eliminated at random, according to
+        the underlying ``sntv`` / ``irv`` steps.
+        If 'order', the lowest-ID tied candidate is preferred in each tie.
+        By default, ``None`` is returned for ties.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary`
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
 
     Examples
     --------
@@ -266,28 +291,35 @@ def top_n_irv(election, n, tiebreaker=None):
 
 def top_n_runoff(election, n, tiebreaker=None):
     """
-    Pick-one top-``n`` primary and a top-two contingent general. [1]_
+    Find the winner of an election using a pick-one top-``n`` primary and a
+    top-two contingent general.
 
     After the top ``n`` candidates by plurality advance, the general election
-    applies the same two-candidate contingent logic as ``runoff`` on the
-    restricted set (first round among finalists only, then pairwise between the
-    top two by first preference among finalists).
+    uses the same two-candidate contingent logic as ``runoff`` on the
+    restricted set of finalists (first round among finalists only, then
+    pairwise between the top two by first preference among finalists). [1]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots.
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
-        Primary cutoff.
+        Number of candidates who advance from the primary.
     tiebreaker : {'random', 'order', None}, optional
+        If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
+        is returned.
+        If 'order', the lowest-ID tied candidate is returned.
+        By default, ``None`` is returned for ties.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary#Variations`
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
 
     Examples
     --------
@@ -308,25 +340,36 @@ def top_n_runoff(election, n, tiebreaker=None):
 
 def top_n_condorcet(election, n, tiebreaker=None):
     """
-    Pick-one top-``n`` primary and a Condorcet pairwise general. [1]_
+    Find the winner of an election using a pick-one top-``n`` primary and a
+    Condorcet pairwise general.
+
+    The primary uses the same top-``n`` rule as ``sntv``.  The general election
+    applies ``condorcet`` to the restricted rankings (no tiebreaker in the
+    general, matching ``condorcet`` itself). [1]_ [2]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots.
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
-        Primary cutoff.
+        Number of candidates who advance from the primary.
     tiebreaker : {'random', 'order', None}, optional
-        Used only for the primary; the general has no tiebreaker (same as
-        ``condorcet``).
+        Used only for the primary.  If there is a tie, and `tiebreaker` is
+        ``'random'``, random tied candidates are returned.
+        If 'order', the lowest-ID tied candidates are returned.
+        By default, ``None`` is returned for ties in the primary.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie in the
+        primary or no Condorcet winner in the general.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary#Variations`
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+    .. [2] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
 
     Examples
     --------
@@ -347,23 +390,40 @@ def top_n_condorcet(election, n, tiebreaker=None):
 
 def irv_primary_top_n_irv(election, n, tiebreaker=None):
     """
-    Ranked IRV-style primary until ``n`` candidates remain, then IRV general. [1]_
+    Find the winner of an election using an IRV-style primary to a slate of
+    ``n``, then an IRV general.
+
+    The primary is ``irv_eliminate_to_n``; the general is ``irv`` on ballots
+    restricted to the surviving finalists. [1]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots.
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
         Target number of finalists after the primary.
     tiebreaker : {'random', 'order', None}, optional
+        If there is a tie, and `tiebreaker` is ``'random'``, tied candidates
+        are eliminated or selected at random in the primary or general.
+        If 'order', the lowest-ID tied candidate is preferred in each tie.
+        By default, ``None`` is returned if there are any ties.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary#Variations`
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+
+    Examples
+    --------
+    >>> A, B, C = 0, 1, 2
+    >>> election = [*6*[[A, B, C]], *3*[[B, A, C]], *1*[[C, B, A]]]
+    >>> irv_primary_top_n_irv(election, 2, tiebreaker='order')
+    0
     """
     finalists = irv_eliminate_to_n(election, n, tiebreaker)
     if finalists is None:
@@ -377,23 +437,40 @@ def irv_primary_top_n_irv(election, n, tiebreaker=None):
 
 def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     """
-    IRV-style primary until ``n`` remain, then top-two contingent general. [1]_
+    Find the winner of an election using an IRV-style primary to a slate of
+    ``n``, then a top-two contingent general.
+
+    The primary is ``irv_eliminate_to_n``; the general is ``runoff`` on
+    ballots restricted to the surviving finalists. [1]_
 
     Parameters
     ----------
     election : array_like
-        Ranked ballots.
+        A collection of ranked ballots.  See `borda` for election format.
+        Currently, this must include full rankings for each voter.
     n : int
         Target number of finalists after the primary.
     tiebreaker : {'random', 'order', None}, optional
+        If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
+        is returned.
+        If 'order', the lowest-ID tied candidate is returned.
+        By default, ``None`` is returned for ties.
 
     Returns
     -------
     winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
 
     References
     ----------
-    .. [1] :wikipedia:`Top-four primary#Variations`
+    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
+
+    Examples
+    --------
+    >>> A, B, C = 0, 1, 2
+    >>> election = [*6*[[A, B, C]], *3*[[B, A, C]], *1*[[C, B, A]]]
+    >>> irv_primary_top_n_runoff(election, 2, tiebreaker='order')
+    0
     """
     finalists = irv_eliminate_to_n(election, n, tiebreaker)
     if finalists is None:
@@ -406,30 +483,159 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
 
 
 def top_four_irv(election, tiebreaker=None):
-    """Same as ``top_n_irv(election, 4, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-four primary and an
+    IRV general.
+
+    Same as ``top_n_irv(election, 4, tiebreaker)``. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_irv`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_irv`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    """
     return top_n_irv(election, 4, tiebreaker)
 
 
 def top_five_irv(election, tiebreaker=None):
-    """Same as ``top_n_irv(election, 5, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-five primary and an
+    IRV general.
+
+    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_irv`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_irv`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    """
     return top_n_irv(election, 5, tiebreaker)
 
 
 def top_four_runoff(election, tiebreaker=None):
-    """Same as ``top_n_runoff(election, 4, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-four primary and a
+    top-two contingent general.
+
+    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_runoff`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_runoff`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    """
     return top_n_runoff(election, 4, tiebreaker)
 
 
 def top_five_runoff(election, tiebreaker=None):
-    """Same as ``top_n_runoff(election, 5, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-five primary and a
+    top-two contingent general.
+
+    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_runoff`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_runoff`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    """
     return top_n_runoff(election, 5, tiebreaker)
 
 
 def top_four_condorcet(election, tiebreaker=None):
-    """Same as ``top_n_condorcet(election, 4, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-four primary and a
+    Condorcet pairwise general.
+
+    Same as ``top_n_condorcet(election, 4, tiebreaker)``. [1]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_condorcet`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_condorcet`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    """
     return top_n_condorcet(election, 4, tiebreaker)
 
 
 def top_five_condorcet(election, tiebreaker=None):
-    """Same as ``top_n_condorcet(election, 5, tiebreaker)``."""
+    """
+    Find the winner of an election using a pick-one top-five primary and a
+    Condorcet pairwise general.
+
+    Same as ``top_n_condorcet(election, 5, tiebreaker)``. [1]_ [2]_
+
+    Parameters
+    ----------
+    election : array_like
+        Passed to `top_n_condorcet`.
+    tiebreaker : {'random', 'order', None}, optional
+        Passed to `top_n_condorcet`.
+
+    Returns
+    -------
+    winner : {int, None}
+        The ID number of the winner, or ``None`` for an unbroken tie.
+
+    References
+    ----------
+    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
+    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
+    """
     return top_n_condorcet(election, 5, tiebreaker)

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -3,26 +3,22 @@ Two-round voting methods that combine a primary (narrowing the field) with a
 general election.
 
 These implement nonpartisan blanket primaries and related reforms: approval
-plus runoff (unified primary), pick-one top-four or top-five with a ranked
-general (Final Four / Final Five), IRV-style primaries that leave a fixed
-slate, and Condorcet in the general.
+plus runoff (unified primary), pick-one top-four or top-five with an IRV
+general (Final Four / Final Five), the same pick-one primary with a
+contingent general among finalists, a ranked sequential primary that leaves
+``n`` survivors (see ``irv(..., n_survivors=n)``) followed by that contingent
+general, and Condorcet in the general.
 """
 import numpy as np
 
-from elsim.methods._common import (_all_indices, _get_tiebreak, _inc_rank_idx,
-                                   _no_tiebreak, _order_tiebreak_elim,
-                                   _order_tiebreak_keep, _random_tiebreak,
-                                   _tally_at_rank_idx)
+from elsim.methods._common import (_get_tiebreak, _no_tiebreak,
+                                   _order_tiebreak_keep, _random_tiebreak)
 from elsim.methods.condorcet import condorcet
 from elsim.methods.fptp import sntv
 from elsim.methods.irv import irv
 from elsim.methods.runoff import runoff
 
 _tiebreak_map_keep = {'order': _order_tiebreak_keep,
-                      'random': _random_tiebreak,
-                      None: _no_tiebreak}
-
-_tiebreak_map_elim = {'order': _order_tiebreak_elim,
                       'random': _random_tiebreak,
                       None: _no_tiebreak}
 
@@ -102,82 +98,6 @@ def _head_to_head_two(finalist_0, finalist_1, election, tiebreaker):
     return finalist_1
 
 
-def irv_eliminate_to_n(election, n, tiebreaker=None):
-    """
-    Find the remaining candidates after an IRV-style sequential elimination
-    primary.
-
-    The candidate with the fewest first-preference votes among those still in
-    the race is eliminated (same rule as ``irv``), and the process repeats until
-    at most ``n`` candidates remain.  This models the ranked primary described
-    in reform proposals for top-four systems. [1]_  FairVote circulated model
-    policy language for top-four and related reforms. [2]_
-
-    Parameters
-    ----------
-    election : array_like
-        A collection of ranked ballots.  See `borda` for election format.
-        Currently, this must include full rankings for each voter.
-    n : int
-        Number of candidates that should remain when the primary ends.
-    tiebreaker : {'random', 'order', None}, optional
-        If there is a tie, and `tiebreaker` is ``'random'``, tied candidates
-        are eliminated or selected at random.
-        If 'order', the lowest-ID tied candidate is preferred in each tie.
-        By default, ``None`` is returned if there are any ties.
-
-    Returns
-    -------
-    finalists : {set of int, None}
-        The set of candidate IDs still in the race, or ``None`` for an
-        unbroken tie during elimination.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
-
-    Examples
-    --------
-    >>> election = [[0, 1, 2], [1, 2, 0], [2, 0, 1]]
-    >>> sorted(irv_eliminate_to_n(election, 2, tiebreaker='order'))
-    [0, 1]
-    """
-    election = np.asarray(election)
-    n_voters, n_cands = election.shape
-    if n < 1:
-        raise ValueError('n must be at least 1')
-    if n >= n_cands:
-        return set(range(n_cands))
-
-    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map_elim)
-
-    voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
-    cand_tallies = np.empty(n_cands, dtype=np.uint)
-
-    _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
-    eliminated_cands = set(_all_indices(cand_tallies.tolist(), 0))
-    if eliminated_cands:
-        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
-
-    while n_cands - len(eliminated_cands) > n:
-        _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
-        cand_tallies_list = cand_tallies.tolist()
-        active_tallies = [cand_tallies_list[c] for c in range(n_cands)
-                          if c not in eliminated_cands]
-        last_place_tally = min(active_tallies)
-        last_place_cands = [c for c in range(n_cands)
-                            if c not in eliminated_cands
-                            and cand_tallies_list[c] == last_place_tally]
-        cand_to_eliminate = tiebreak(last_place_cands)[0]
-        if cand_to_eliminate is None:
-            return None
-        eliminated_cands.add(cand_to_eliminate)
-        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
-
-    return {c for c in range(n_cands) if c not in eliminated_cands}
-
-
 def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     """
     Find the winner of an election using a top-two approval primary and a
@@ -188,9 +108,6 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     ballots (the contingent vote, same ranked-ballot abstraction as ``runoff``
     uses between its finalists). [1]_ [2]_  Delemazure et al. define and study
     the approval-with-runoff family in the computational social choice literature. [3]_
-    St. Louis voters adopted this pattern for municipal offices in 2020; the
-    city's election materials illustrate the approve-many primary and two-candidate
-    runoff. [4]_
 
     Parameters
     ----------
@@ -215,7 +132,6 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     .. [1] `Unified primary <https://en.wikipedia.org/wiki/Unified_primary>`__
     .. [2] `Contingent vote <https://en.wikipedia.org/wiki/Contingent_vote>`__
     .. [3] `Delemazure et al., "Approval with Runoff" (IJCAI 2022) <https://doi.org/10.24963/ijcai.2022/33>`__
-    .. [4] `City of St. Louis, sample general-election ballot (Nov. 2020, PDF) <https://www.stlouis-mo.gov/government/departments/board-election-commissioners/documents/upload/Nov20-Final-All-Races-Sample-Ballot-9-9-20-1.pdf>`__
 
     Examples
     --------
@@ -252,11 +168,9 @@ def top_n_irv(election, n, tiebreaker=None):
 
     The ``n`` candidates with the most first-preference votes advance (same
     rule as ``sntv``).  The winner is then chosen by ``irv`` on the same
-    rankings restricted to those finalists (as used in Alaska-style top-four
-    with an IRV general). [1]_  Alaska's Division of Elections describes the
-    nonpartisan top-four primary and ranked-choice general in official voter
-    materials. [2]_  FairVote published an early top-four policy guide with
-    model legislative language. [3]_
+    rankings restricted to those finalists.  ``top_n_irv(..., n=4)`` matches
+    Alaska's nonpartisan top-four primary with an IRV general; ``n`` = 5 is
+    the ranked general used in Final Five-style proposals. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -264,8 +178,9 @@ def top_n_irv(election, n, tiebreaker=None):
         A collection of ranked ballots.  See `borda` for election format.
         Currently, this must include full rankings for each voter.
     n : int
-        Number of candidates who advance from the primary (4 for Final Four,
-        5 for Final Five).
+        Number of candidates who advance from the primary (``n`` = 4 is Final
+        Four; ``n`` = 5 is the slate size in Final Five together with this IRV
+        general).
     tiebreaker : {'random', 'order', None}, optional
         If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
         is returned or tied candidates are eliminated at random, according to
@@ -304,16 +219,15 @@ def top_n_irv(election, n, tiebreaker=None):
 def top_n_runoff(election, n, tiebreaker=None):
     """
     Find the winner of an election using a pick-one top-``n`` primary and a
-    top-two contingent general.
+    contingent general among those finalists.
 
-    After the top ``n`` candidates by plurality advance, the general election
-    uses the same two-candidate contingent logic as ``runoff`` on the
-    restricted set of finalists (first round among finalists only, then
-    pairwise between the top two by first preference among finalists). [1]_
-    Alaska's Division of Elections documents the combined top-four primary and
-    ranked general election. [2]_  The Electoral Reform Society describes the
-    contingent / supplementary vote as the two-stage reduction to a pairwise
-    majority choice. [3]_
+    The primary is ``sntv``: the ``n`` candidates with the most first-preference
+    votes in the full field advance.  The general is ``runoff`` applied to the
+    sub-election that keeps only those finalists on each ballot.  That is not
+    the same as calling ``runoff`` on the original ballots, because ``runoff``
+    here first ranks first preferences **among the finalists only** to pick
+    two of them, then breaks a deadlock with a pairwise vote on the same
+    restricted rankings (the contingent vote, as in ``runoff``). [1]_ [2]_
 
     Parameters
     ----------
@@ -336,8 +250,7 @@ def top_n_runoff(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
-    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
+    .. [2] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
 
     Examples
     --------
@@ -363,8 +276,9 @@ def top_n_condorcet(election, n, tiebreaker=None):
 
     The primary uses the same top-``n`` rule as ``sntv``.  The general election
     applies ``condorcet`` to the restricted rankings (no tiebreaker in the
-    general, matching ``condorcet`` itself). [1]_      Condorcet's 1785 essay defines pairwise majority comparisons among
-    candidates. [2]_  A modern overview is in [3]_.
+    general, matching ``condorcet`` itself). [1]_  Condorcet's 1785 essay
+    defines pairwise majority comparisons among candidates. [2]_  A modern
+    overview is in [3]_.
 
     Parameters
     ----------
@@ -408,65 +322,16 @@ def top_n_condorcet(election, n, tiebreaker=None):
     return int(new_to_old[w])
 
 
-def irv_primary_top_n_irv(election, n, tiebreaker=None):
-    """
-    Find the winner of an election using an IRV-style primary to a slate of
-    ``n``, then an IRV general.
-
-    The primary is ``irv_eliminate_to_n``; the general is ``irv`` on ballots
-    restricted to the surviving finalists. [1]_  Hare's treatise is a
-    foundational English-language source for transferable-vote elimination
-    rules of the kind ``irv`` implements. [2]_
-
-    Parameters
-    ----------
-    election : array_like
-        A collection of ranked ballots.  See `borda` for election format.
-        Currently, this must include full rankings for each voter.
-    n : int
-        Target number of finalists after the primary.
-    tiebreaker : {'random', 'order', None}, optional
-        If there is a tie, and `tiebreaker` is ``'random'``, tied candidates
-        are eliminated or selected at random in the primary or general.
-        If 'order', the lowest-ID tied candidate is preferred in each tie.
-        By default, ``None`` is returned if there are any ties.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Hare (1859), *A Treatise on the Election of Representatives, Parliamentary and Municipal* (Internet Archive) <https://archive.org/details/atreatiseonelec01haregoog>`__
-
-    Examples
-    --------
-    >>> A, B, C = 0, 1, 2
-    >>> election = [*6*[[A, B, C]], *3*[[B, A, C]], *1*[[C, B, A]]]
-    >>> irv_primary_top_n_irv(election, 2, tiebreaker='order')
-    0
-    """
-    finalists = irv_eliminate_to_n(election, n, tiebreaker)
-    if finalists is None:
-        return None
-    sub, new_to_old = _restrict_ballots(election, finalists)
-    w = irv(sub, tiebreaker)
-    if w is None:
-        return None
-    return int(new_to_old[w])
-
-
 def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     """
-    Find the winner of an election using an IRV-style primary to a slate of
-    ``n``, then a top-two contingent general.
+    Find the winner of an election using a ranked sequential primary to a
+    slate of ``n``, then a contingent general among those finalists.
 
-    The primary is ``irv_eliminate_to_n``; the general is ``runoff`` on
-    ballots restricted to the surviving finalists. [1]_  Alaska's Division of
-    Elections describes the top-four primary with a ranked general election,
-    which matches the same two-stage structure at ``n`` = 4. [2]_
+    The primary is ``irv(..., n_survivors=n)``: the same last-place elimination
+    and transfers as ``irv``, but without stopping when someone reaches an
+    overall majority, until ``n`` candidates remain.  The general is ``runoff``
+    on ballots restricted to that slate (first preferences among finalists
+    only to pick two of them, then the pairwise stage as in ``runoff``). [1]_ [2]_
 
     Parameters
     ----------
@@ -489,7 +354,7 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
+    .. [2] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
 
     Examples
     --------
@@ -498,7 +363,7 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     >>> irv_primary_top_n_runoff(election, 2, tiebreaker='order')
     0
     """
-    finalists = irv_eliminate_to_n(election, n, tiebreaker)
+    finalists = irv(election, tiebreaker, n_survivors=n)
     if finalists is None:
         return None
     sub, new_to_old = _restrict_ballots(election, finalists)
@@ -568,9 +433,9 @@ def top_five_irv(election, tiebreaker=None):
 def top_four_runoff(election, tiebreaker=None):
     """
     Find the winner of an election using a pick-one top-four primary and a
-    top-two contingent general.
+    contingent general among finalists.
 
-    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
+    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_ [2]_
 
     Parameters
     ----------
@@ -587,8 +452,7 @@ def top_four_runoff(election, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
-    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
+    .. [2] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
     """
     return top_n_runoff(election, 4, tiebreaker)
 
@@ -596,9 +460,9 @@ def top_four_runoff(election, tiebreaker=None):
 def top_five_runoff(election, tiebreaker=None):
     """
     Find the winner of an election using a pick-one top-five primary and a
-    top-two contingent general.
+    contingent general among finalists.
 
-    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_ [5]_
+    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_
 
     Parameters
     ----------
@@ -616,9 +480,8 @@ def top_five_runoff(election, tiebreaker=None):
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
     .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
-    .. [3] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
-    .. [4] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
-    .. [5] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
+    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
+    .. [4] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
     """
     return top_n_runoff(election, 5, tiebreaker)
 

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -5,10 +5,7 @@ general election.
 These implement nonpartisan blanket primaries and related reforms: approval
 plus runoff (unified primary), pick-one top-four or top-five with a ranked
 general (Final Four / Final Five), IRV-style primaries that leave a fixed
-slate, and Condorcet in the general.  Each public function's docstring cites
-encyclopedia summaries where helpful and, where available, primary sources
-(peer-reviewed definitions, founding monographs, official election-administration
-pages, or reform white papers).
+slate, and Condorcet in the general.
 """
 import numpy as np
 
@@ -366,9 +363,8 @@ def top_n_condorcet(election, n, tiebreaker=None):
 
     The primary uses the same top-``n`` rule as ``sntv``.  The general election
     applies ``condorcet`` to the restricted rankings (no tiebreaker in the
-    general, matching ``condorcet`` itself). [1]_  Condorcet's 1785 essay is the
-    classical source for pairwise majority comparisons. [2]_  See also the
-    encyclopedia overview of Condorcet methods. [3]_
+    general, matching ``condorcet`` itself). [1]_      Condorcet's 1785 essay defines pairwise majority comparisons among
+    candidates. [2]_  A modern overview is in [3]_.
 
     Parameters
     ----------
@@ -545,9 +541,8 @@ def top_five_irv(election, tiebreaker=None):
     Find the winner of an election using a pick-one top-five primary and an
     IRV general.
 
-    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_  Gehl and
-    Porter's report is a widely cited business-school source for the "Final
-    Five" reform packaging. [3]_
+    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_  Gehl & Porter
+    (2017) introduce the Final Five reform framing. [3]_
 
     Parameters
     ----------

--- a/elsim/methods/blanket_primary.py
+++ b/elsim/methods/blanket_primary.py
@@ -2,12 +2,11 @@
 Two-round voting methods that combine a primary (narrowing the field) with a
 general election.
 
-These implement nonpartisan blanket primaries and related reforms: approval
-plus runoff (unified primary), pick-one top-four or top-five with an IRV
-general (Final Four / Final Five), the same pick-one primary with a
-contingent general among finalists, a ranked sequential primary that leaves
-``n`` survivors (see ``irv(..., n_survivors=n)``) followed by that contingent
-general, and Condorcet in the general.
+These implement nonpartisan blanket primaries and related reforms: Unified
+Primary (top-two approval primary plus a general election using the contingent
+vote), pick-one Top Four or Final Five with an IRV general, pick-one Top Four
+or Final Five with a general election using the contingent vote among
+finalists, ``irv(..., n_winners=n)`` followed by that same contingent-vote general among finalists, and a Condorcet general.
 """
 import numpy as np
 
@@ -101,13 +100,15 @@ def _head_to_head_two(finalist_0, finalist_1, election, tiebreaker):
 def approval_runoff(approval_election, ranked_election, tiebreaker=None):
     """
     Find the winner of an election using a top-two approval primary and a
-    pairwise runoff on ranked ballots.
+    general election under the contingent vote on ranked ballots.
+
+    Also known as the Unified Primary. [1]_
 
     The two candidates with the most approvals advance.  The general election
-    is modeled as a pairwise majority vote between those two on the ranked
-    ballots (the contingent vote, same ranked-ballot abstraction as ``runoff``
-    uses between its finalists). [1]_ [2]_  Delemazure et al. define and study
-    the approval-with-runoff family in the computational social choice literature. [3]_
+    is a pairwise majority vote between those two on the ranked ballots (the
+    contingent vote, the same ranked-ballot abstraction as ``runoff`` uses
+    between its finalists). [2]_  Delemazure et al. study this approval-with-runoff
+    pattern in the computational social choice literature. [3]_
 
     Parameters
     ----------
@@ -129,7 +130,7 @@ def approval_runoff(approval_election, ranked_election, tiebreaker=None):
 
     References
     ----------
-    .. [1] `Unified primary <https://en.wikipedia.org/wiki/Unified_primary>`__
+    .. [1] `Unified Primary <https://en.wikipedia.org/wiki/Unified_primary>`__
     .. [2] `Contingent vote <https://en.wikipedia.org/wiki/Contingent_vote>`__
     .. [3] `Delemazure et al., "Approval with Runoff" (IJCAI 2022) <https://doi.org/10.24963/ijcai.2022/33>`__
 
@@ -169,8 +170,8 @@ def top_n_irv(election, n, tiebreaker=None):
     The ``n`` candidates with the most first-preference votes advance (same
     rule as ``sntv``).  The winner is then chosen by ``irv`` on the same
     rankings restricted to those finalists.  ``top_n_irv(..., n=4)`` matches
-    Alaska's nonpartisan top-four primary with an IRV general; ``n`` = 5 is
-    the ranked general used in Final Five-style proposals. [1]_ [2]_ [3]_
+    Alaska's Top Four primary with an IRV general; ``n`` = 5 matches the Final
+    Five package (top-five primary plus this IRV general). [1]_ [2]_ [3]_ [4]_
 
     Parameters
     ----------
@@ -178,9 +179,9 @@ def top_n_irv(election, n, tiebreaker=None):
         A collection of ranked ballots.  See `borda` for election format.
         Currently, this must include full rankings for each voter.
     n : int
-        Number of candidates who advance from the primary (``n`` = 4 is Final
-        Four; ``n`` = 5 is the slate size in Final Five together with this IRV
-        general).
+        Number of candidates who advance from the primary (``n`` = 4 for
+        Alaska's Top Four; ``n`` = 5 for the primary slate in Final Five with
+        this IRV general).
     tiebreaker : {'random', 'order', None}, optional
         If there is a tie, and `tiebreaker` is ``'random'``, a random finalist
         is returned or tied candidates are eliminated at random, according to
@@ -198,6 +199,7 @@ def top_n_irv(election, n, tiebreaker=None):
     .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
     .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
     .. [3] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
+    .. [4] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
 
     Examples
     --------
@@ -219,14 +221,14 @@ def top_n_irv(election, n, tiebreaker=None):
 def top_n_runoff(election, n, tiebreaker=None):
     """
     Find the winner of an election using a pick-one top-``n`` primary and a
-    contingent general among those finalists.
+    general election using the contingent vote among those finalists.
 
     The primary is ``sntv``: the ``n`` candidates with the most first-preference
     votes in the full field advance.  The general is ``runoff`` applied to the
     sub-election that keeps only those finalists on each ballot.  That is not
-    the same as calling ``runoff`` on the original ballots, because ``runoff``
-    here first ranks first preferences **among the finalists only** to pick
-    two of them, then breaks a deadlock with a pairwise vote on the same
+    the same as calling ``runoff`` on the original ballots, because here the
+    first stage of ``runoff`` counts first preferences **among the finalists
+    only** to pick two of them, then the pairwise stage uses the same
     restricted rankings (the contingent vote, as in ``runoff``). [1]_ [2]_
 
     Parameters
@@ -250,7 +252,7 @@ def top_n_runoff(election, n, tiebreaker=None):
     References
     ----------
     .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
+    .. [2] `Contingent vote <https://en.wikipedia.org/wiki/Contingent_vote>`__
 
     Examples
     --------
@@ -272,7 +274,7 @@ def top_n_runoff(election, n, tiebreaker=None):
 def top_n_condorcet(election, n, tiebreaker=None):
     """
     Find the winner of an election using a pick-one top-``n`` primary and a
-    Condorcet pairwise general.
+    Condorcet general.
 
     The primary uses the same top-``n`` rule as ``sntv``.  The general election
     applies ``condorcet`` to the restricted rankings (no tiebreaker in the
@@ -325,13 +327,15 @@ def top_n_condorcet(election, n, tiebreaker=None):
 def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     """
     Find the winner of an election using a ranked sequential primary to a
-    slate of ``n``, then a contingent general among those finalists.
+    slate of ``n``, then a general election using the contingent vote among
+    those finalists.
 
-    The primary is ``irv(..., n_survivors=n)``: the same last-place elimination
+    The primary is ``irv(..., n_winners=n)``: the same last-place elimination
     and transfers as ``irv``, but without stopping when someone reaches an
     overall majority, until ``n`` candidates remain.  The general is ``runoff``
     on ballots restricted to that slate (first preferences among finalists
-    only to pick two of them, then the pairwise stage as in ``runoff``). [1]_ [2]_
+    only to pick two of them, then the pairwise stage of the contingent vote,
+    as in ``runoff``). [1]_ [2]_
 
     Parameters
     ----------
@@ -363,7 +367,7 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     >>> irv_primary_top_n_runoff(election, 2, tiebreaker='order')
     0
     """
-    finalists = irv(election, tiebreaker, n_survivors=n)
+    finalists = irv(election, tiebreaker, n_winners=n)
     if finalists is None:
         return None
     sub, new_to_old = _restrict_ballots(election, finalists)
@@ -371,174 +375,3 @@ def irv_primary_top_n_runoff(election, n, tiebreaker=None):
     if w is None:
         return None
     return int(new_to_old[w])
-
-
-def top_four_irv(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-four primary and an
-    IRV general.
-
-    Same as ``top_n_irv(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_irv`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_irv`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
-    .. [2] `Alaska Division of Elections, "Ranked Choice Voting" (top-four primary and RCV general) <https://www.elections.alaska.gov/Core/RCV.php>`__
-    .. [3] `FairVote, "Top Four" policy guide (PDF, 2013) <https://archive3.fairvote.org/assets/Top-Four-Policy-Guide.pdf>`__
-    """
-    return top_n_irv(election, 4, tiebreaker)
-
-
-def top_five_irv(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-five primary and an
-    IRV general.
-
-    Same as ``top_n_irv(election, 5, tiebreaker)``. [1]_ [2]_  Gehl & Porter
-    (2017) introduce the Final Five reform framing. [3]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_irv`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_irv`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary <https://en.wikipedia.org/wiki/Top-four_primary>`__
-    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
-    .. [3] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
-    """
-    return top_n_irv(election, 5, tiebreaker)
-
-
-def top_four_runoff(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-four primary and a
-    contingent general among finalists.
-
-    Same as ``top_n_runoff(election, 4, tiebreaker)``. [1]_ [2]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_runoff`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_runoff`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
-    """
-    return top_n_runoff(election, 4, tiebreaker)
-
-
-def top_five_runoff(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-five primary and a
-    contingent general among finalists.
-
-    Same as ``top_n_runoff(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_runoff`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_runoff`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
-    .. [3] `Electoral Reform Society, "What is the Supplementary Vote?" <https://www.electoral-reform.org.uk/voting-systems/types-of-voting-systems/supplementary-vote-sv/>`__
-    .. [4] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
-    """
-    return top_n_runoff(election, 5, tiebreaker)
-
-
-def top_four_condorcet(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-four primary and a
-    Condorcet pairwise general.
-
-    Same as ``top_n_condorcet(election, 4, tiebreaker)``. [1]_ [2]_ [3]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_condorcet`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_condorcet`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Condorcet (1785), *Essai sur l'application de l'analyse à la probabilité des décisions rendues à la pluralité des voix* (BnF Gallica) <https://gallica.bnf.fr/ark:/12148/bpt6k417181>`__
-    .. [3] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
-    """
-    return top_n_condorcet(election, 4, tiebreaker)
-
-
-def top_five_condorcet(election, tiebreaker=None):
-    """
-    Find the winner of an election using a pick-one top-five primary and a
-    Condorcet pairwise general.
-
-    Same as ``top_n_condorcet(election, 5, tiebreaker)``. [1]_ [2]_ [3]_ [4]_ [5]_
-
-    Parameters
-    ----------
-    election : array_like
-        Passed to `top_n_condorcet`.
-    tiebreaker : {'random', 'order', None}, optional
-        Passed to `top_n_condorcet`.
-
-    Returns
-    -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
-
-    References
-    ----------
-    .. [1] `Top-four primary: Variations <https://en.wikipedia.org/wiki/Top-four_primary#Variations>`__
-    .. [2] `Final Five Voting <https://en.wikipedia.org/wiki/Top-four_primary#Final_Five_Voting>`__
-    .. [3] `Condorcet (1785), *Essai sur l'application de l'analyse à la probabilité des décisions rendues à la pluralité des voix* (BnF Gallica) <https://gallica.bnf.fr/ark:/12148/bpt6k417181>`__
-    .. [4] `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`__
-    .. [5] `Gehl & Porter (2017), "Why Competition in the Politics Industry is Failing America" (PDF) <https://www.hbs.edu/competitiveness/Documents/why-competition-in-the-politics-industry-is-failing-america.pdf>`__
-    """
-    return top_n_condorcet(election, 5, tiebreaker)

--- a/elsim/methods/irv.py
+++ b/elsim/methods/irv.py
@@ -9,10 +9,11 @@ _tiebreak_map = {'order': _order_tiebreak_elim,
                  None: _no_tiebreak}
 
 
-def _irv_eliminate_until_n_remain(election, tiebreaker, n):
+def _irv_eliminate_until_n_winners_remain(election, tiebreaker, n_winners):
     """
     Same elimination rule as `irv`, but do not stop on a majority; keep
-    eliminating the last-place active candidate until at most ``n`` remain.
+    eliminating the last-place active candidate until at most ``n_winners``
+    remain.
     """
     n_voters, n_cands = election.shape
     tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
@@ -25,7 +26,7 @@ def _irv_eliminate_until_n_remain(election, tiebreaker, n):
     if eliminated_cands:
         _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
 
-    while n_cands - len(eliminated_cands) > n:
+    while n_cands - len(eliminated_cands) > n_winners:
         _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
         cand_tallies_list = cand_tallies.tolist()
         active_tallies = [cand_tallies_list[c] for c in range(n_cands)
@@ -43,7 +44,7 @@ def _irv_eliminate_until_n_remain(election, tiebreaker, n):
     return {c for c in range(n_cands) if c not in eliminated_cands}
 
 
-def irv(election, tiebreaker=None, *, n_survivors=None):
+def irv(election, tiebreaker=None, *, n_winners=None):
     """
     Find the winner of an election using instant-runoff voting.
 
@@ -71,7 +72,7 @@ def irv(election, tiebreaker=None, *, n_survivors=None):
         are eliminated or selected at random.
         If 'order', the lowest-ID tied candidate is preferred in each tie.
         By default, ``None`` is returned if there are any ties.
-    n_survivors : int, optional
+    n_winners : int, optional
         If omitted (default), return the usual single IRV winner.
         If ``1``, same as omitted (one winner).
         If ``k`` with ``1 < k < n_candidates``, return the set of candidate IDs
@@ -85,12 +86,12 @@ def irv(election, tiebreaker=None, *, n_survivors=None):
     Returns
     -------
     outcome : {int, set of int, None}
-        If ``n_survivors`` is omitted or ``1``, the winner's ID, or ``None`` for
+        If ``n_winners`` is omitted or ``1``, the winner's ID, or ``None`` for
         an unbroken tie.
-        If ``n_survivors`` is strictly between ``1`` and the number of
+        If ``n_winners`` is strictly between ``1`` and the number of
         candidates, the set of surviving candidate IDs, or ``None`` for an
         unbroken tie during elimination.
-        If ``n_survivors`` is greater than or equal to the number of candidates,
+        If ``n_winners`` is greater than or equal to the number of candidates,
         the set of all candidate IDs.
 
     References
@@ -121,7 +122,7 @@ def irv(election, tiebreaker=None, *, n_survivors=None):
     >>> irv(election)
     0
 
-    The same ballots with ``n_survivors`` = 2 (no majority short-circuit;
+    The same ballots with ``n_winners`` = 2 (no majority short-circuit;
     eliminate last place once so two candidates remain):
 
     >>> election_b = [[A, C, B],
@@ -130,20 +131,20 @@ def irv(election, tiebreaker=None, *, n_survivors=None):
     ...               [B, C, A],
     ...               [C, A, B],
     ...               ]
-    >>> sorted(irv(election_b, n_survivors=2, tiebreaker='order'))
+    >>> sorted(irv(election_b, n_winners=2, tiebreaker='order'))
     [0, 1]
     """
     election = np.asarray(election)
     n_voters, n_cands = election.shape
 
-    if n_survivors is not None:
-        if n_survivors < 1:
-            raise ValueError('n_survivors must be at least 1')
-        if n_survivors >= n_cands:
+    if n_winners is not None:
+        if n_winners < 1:
+            raise ValueError('n_winners must be at least 1')
+        if n_winners >= n_cands:
             return set(range(n_cands))
-        if n_survivors > 1:
-            return _irv_eliminate_until_n_remain(election, tiebreaker,
-                                                 n_survivors)
+        if n_winners > 1:
+            return _irv_eliminate_until_n_winners_remain(election, tiebreaker,
+                                                         n_winners)
 
     tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
     voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)

--- a/elsim/methods/irv.py
+++ b/elsim/methods/irv.py
@@ -9,7 +9,41 @@ _tiebreak_map = {'order': _order_tiebreak_elim,
                  None: _no_tiebreak}
 
 
-def irv(election, tiebreaker=None):
+def _irv_eliminate_until_n_remain(election, tiebreaker, n):
+    """
+    Same elimination rule as `irv`, but do not stop on a majority; keep
+    eliminating the last-place active candidate until at most ``n`` remain.
+    """
+    n_voters, n_cands = election.shape
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
+
+    voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
+    cand_tallies = np.empty(n_cands, dtype=np.uint)
+
+    _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+    eliminated_cands = set(_all_indices(cand_tallies, 0))
+    if eliminated_cands:
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+
+    while n_cands - len(eliminated_cands) > n:
+        _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+        cand_tallies_list = cand_tallies.tolist()
+        active_tallies = [cand_tallies_list[c] for c in range(n_cands)
+                          if c not in eliminated_cands]
+        last_place_tally = min(active_tallies)
+        last_place_cands = [c for c in range(n_cands)
+                            if c not in eliminated_cands
+                            and cand_tallies_list[c] == last_place_tally]
+        cand_to_eliminate = tiebreak(last_place_cands)[0]
+        if cand_to_eliminate is None:
+            return None
+        eliminated_cands.add(cand_to_eliminate)
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+
+    return {c for c in range(n_cands) if c not in eliminated_cands}
+
+
+def irv(election, tiebreaker=None, *, n_survivors=None):
     """
     Find the winner of an election using instant-runoff voting.
 
@@ -37,11 +71,27 @@ def irv(election, tiebreaker=None):
         are eliminated or selected at random.
         If 'order', the lowest-ID tied candidate is preferred in each tie.
         By default, ``None`` is returned if there are any ties.
+    n_survivors : int, optional
+        If omitted (default), return the usual single IRV winner.
+        If ``1``, same as omitted (one winner).
+        If ``k`` with ``1 < k < n_candidates``, return the set of candidate IDs
+        still standing after repeatedly eliminating the last-place active
+        candidate (same transfer rule as above) until ``k`` remain, without
+        stopping early when someone has a majority.  This models a ranked
+        primary that narrows the field to ``k`` for a later round.
+        If ``k`` is greater than or equal to the number of candidates, every
+        candidate is returned as a set.
 
     Returns
     -------
-    winner : {int, None}
-        The ID number of the winner, or ``None`` for an unbroken tie.
+    outcome : {int, set of int, None}
+        If ``n_survivors`` is omitted or ``1``, the winner's ID, or ``None`` for
+        an unbroken tie.
+        If ``n_survivors`` is strictly between ``1`` and the number of
+        candidates, the set of surviving candidate IDs, or ``None`` for an
+        unbroken tie during elimination.
+        If ``n_survivors`` is greater than or equal to the number of candidates,
+        the set of all candidate IDs.
 
     References
     ----------
@@ -70,9 +120,31 @@ def irv(election, tiebreaker=None):
 
     >>> irv(election)
     0
+
+    The same ballots with ``n_survivors`` = 2 (no majority short-circuit;
+    eliminate last place once so two candidates remain):
+
+    >>> election_b = [[A, C, B],
+    ...               [A, C, B],
+    ...               [B, C, A],
+    ...               [B, C, A],
+    ...               [C, A, B],
+    ...               ]
+    >>> sorted(irv(election_b, n_survivors=2, tiebreaker='order'))
+    [0, 1]
     """
     election = np.asarray(election)
     n_voters, n_cands = election.shape
+
+    if n_survivors is not None:
+        if n_survivors < 1:
+            raise ValueError('n_survivors must be at least 1')
+        if n_survivors >= n_cands:
+            return set(range(n_cands))
+        if n_survivors > 1:
+            return _irv_eliminate_until_n_remain(election, tiebreaker,
+                                                 n_survivors)
+
     tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
     voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
     cand_tallies = np.empty(n_cands, dtype=np.uint)

--- a/elsim/methods/irv.py
+++ b/elsim/methods/irv.py
@@ -20,28 +20,29 @@ def _irv_eliminate_until_n_winners_remain(election, tiebreaker, n_winners):
 
     voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
     cand_tallies = np.empty(n_cands, dtype=np.uint)
+    eliminated_mask = np.zeros(n_cands, dtype=bool)
 
     _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
-    eliminated_cands = set(_all_indices(cand_tallies, 0))
-    if eliminated_cands:
-        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+    eliminated_mask[_all_indices(cand_tallies, 0)] = True
+    if eliminated_mask.any():
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_mask)
 
-    while n_cands - len(eliminated_cands) > n_winners:
+    while n_cands - eliminated_mask.sum() > n_winners:
         _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
         cand_tallies_list = cand_tallies.tolist()
         active_tallies = [cand_tallies_list[c] for c in range(n_cands)
-                          if c not in eliminated_cands]
+                          if not eliminated_mask[c]]
         last_place_tally = min(active_tallies)
         last_place_cands = [c for c in range(n_cands)
-                            if c not in eliminated_cands
+                            if not eliminated_mask[c]
                             and cand_tallies_list[c] == last_place_tally]
         cand_to_eliminate = tiebreak(last_place_cands)[0]
         if cand_to_eliminate is None:
             return None
-        eliminated_cands.add(cand_to_eliminate)
-        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+        eliminated_mask[cand_to_eliminate] = True
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_mask)
 
-    return {c for c in range(n_cands) if c not in eliminated_cands}
+    return {c for c in range(n_cands) if not eliminated_mask[c]}
 
 
 def irv(election, tiebreaker=None, *, n_winners=None):

--- a/tests/test_blanket_primary.py
+++ b/tests/test_blanket_primary.py
@@ -3,8 +3,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import integers, lists, permutations
 
-from elsim.methods import (approval_runoff, irv, irv_eliminate_to_n,
-                           irv_primary_top_n_irv, irv_primary_top_n_runoff,
+from elsim.methods import (approval_runoff, irv, irv_primary_top_n_runoff,
                            runoff, top_five_condorcet, top_four_irv,
                            top_four_runoff, top_five_irv, top_n_condorcet,
                            top_n_irv, top_n_runoff)
@@ -46,39 +45,39 @@ def test_top_four_runoff_tennessee(tiebreaker):
 
 
 @pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
-def test_irv_primary_variants_tennessee(tiebreaker):
+def test_irv_primary_runoff_tennessee(tiebreaker):
     Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
     election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
                 *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
                 *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
                 *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
                 ]
-    assert irv_primary_top_n_irv(election, 4, tiebreaker) == Knoxville
     assert irv_primary_top_n_runoff(election, 4, tiebreaker) == runoff(
         election, tiebreaker)
 
 
-def test_irv_eliminate_to_n_three_cycle():
+def test_irv_n_survivors_three_cycle():
     election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
-    assert irv_eliminate_to_n(election, 2) is None
-    assert sorted(irv_eliminate_to_n(election, 2, tiebreaker='order')) == [0, 1]
+    assert irv(election, n_survivors=2) is None
+    assert sorted(irv(election, n_survivors=2, tiebreaker='order')) == [0, 1]
 
 
-def test_irv_eliminate_to_n_invalid_n():
-    with pytest.raises(ValueError, match='n must be at least 1'):
-        irv_eliminate_to_n([[0, 1]], 0)
+def test_irv_n_survivors_invalid_n():
+    with pytest.raises(ValueError, match='n_survivors must be at least 1'):
+        irv([[0, 1]], n_survivors=0)
 
 
-def test_irv_eliminate_to_n_all_survive_when_n_ge_total():
-    assert irv_eliminate_to_n(np.array([[0, 1], [1, 0]]), 2, 'order') == {0, 1}
+def test_irv_n_survivors_all_survive_when_n_ge_total():
+    assert irv(np.array([[0, 1], [1, 0]]), n_survivors=2,
+                tiebreaker='order') == {0, 1}
 
 
-def test_irv_eliminate_to_n_pre_elimination_zero_first_place():
+def test_irv_n_survivors_pre_elimination_zero_first_place():
     election = np.array([[0, 1, 2, 3],
                          [0, 1, 2, 3],
                          [1, 0, 2, 3],
                          [1, 0, 2, 3]])
-    assert irv_eliminate_to_n(election, 2, tiebreaker='order') == {0, 1}
+    assert irv(election, n_survivors=2, tiebreaker='order') == {0, 1}
 
 
 def test__top_n_from_plurality_tallies():
@@ -170,13 +169,9 @@ def test_top_five_condorcet_smoke():
     assert top_five_condorcet([[0, 1], [0, 1], [1, 0]], tiebreaker='order') == 0
 
 
-def test_irv_primary_top_n_returns_none():
-    assert irv_primary_top_n_irv([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 2,
-                                 tiebreaker=None) is None
-    assert irv_primary_top_n_irv([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 3,
-                                 tiebreaker=None) is None
+def test_irv_primary_top_n_runoff_returns_none():
     assert irv_primary_top_n_runoff([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 2,
-                                      tiebreaker=None) is None
+                                    tiebreaker=None) is None
 
     election = np.array([[2, 0, 1],
                          [0, 1, 2],
@@ -212,7 +207,7 @@ def test_blanket_methods_reject_invalid_tiebreaker():
     with pytest.raises(ValueError):
         top_n_condorcet(election, 2, tiebreaker='duel')
     with pytest.raises(ValueError):
-        irv_eliminate_to_n(election, 2, tiebreaker='duel')
+        irv(election, tiebreaker='duel', n_survivors=2)
 
 
 @pytest.mark.parametrize('tiebreaker', ['random', 'order'])

--- a/tests/test_blanket_primary.py
+++ b/tests/test_blanket_primary.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis.strategies import integers, lists, permutations
+
+from elsim.methods import (approval_runoff, irv, irv_eliminate_to_n,
+                           irv_primary_top_n_irv, irv_primary_top_n_runoff,
+                           runoff, top_four_irv, top_four_runoff, top_five_irv,
+                           top_n_condorcet, top_n_irv, top_n_runoff)
+
+
+def complete_ranked_ballots(min_cands=3, max_cands=256, min_voters=1,
+                            max_voters=1000):
+    n_cands = integers(min_value=min_cands, max_value=max_cands)
+    return n_cands.flatmap(lambda n: lists(permutations(range(n)),
+                                           min_size=min_voters,
+                                           max_size=max_voters))
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_top_four_irv_tennessee(tiebreaker):
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert top_four_irv(election, tiebreaker) == Knoxville
+    assert top_five_irv(election, tiebreaker) == Knoxville
+    assert irv(election, tiebreaker) == Knoxville
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_top_four_runoff_tennessee(tiebreaker):
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert top_four_runoff(election, tiebreaker) == runoff(
+        election, tiebreaker)
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_irv_primary_variants_tennessee(tiebreaker):
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert irv_primary_top_n_irv(election, 4, tiebreaker) == Knoxville
+    assert irv_primary_top_n_runoff(election, 4, tiebreaker) == runoff(
+        election, tiebreaker)
+
+
+def test_irv_eliminate_to_n_three_cycle():
+    election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
+    assert irv_eliminate_to_n(election, 2) is None
+    assert sorted(irv_eliminate_to_n(election, 2, tiebreaker='order')) == [0, 1]
+
+
+def test_approval_runoff_matches_head_to_head():
+    A, B, C = 0, 1, 2
+    approvals = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1]], dtype=np.uint8)
+    ranked = np.array([[A, B, C], [B, A, C], [C, B, A]])
+    assert approval_runoff(approvals, ranked, tiebreaker='order') == 1
+
+
+def test_approval_runoff_row_mismatch():
+    with pytest.raises(ValueError, match='same number of rows'):
+        approval_runoff([[1, 0]], [[0, 1], [1, 0]])
+
+
+def test_blanket_methods_reject_invalid_tiebreaker():
+    election = [[0, 1, 2], [1, 2, 0], [2, 0, 1]]
+    with pytest.raises(ValueError):
+        top_n_irv(election, 2, tiebreaker='duel')
+    with pytest.raises(ValueError):
+        top_n_runoff(election, 2, tiebreaker='duel')
+    with pytest.raises(ValueError):
+        top_n_condorcet(election, 2, tiebreaker='duel')
+    with pytest.raises(ValueError):
+        irv_eliminate_to_n(election, 2, tiebreaker='duel')
+
+
+@pytest.mark.parametrize('tiebreaker', ['random', 'order'])
+@given(election=complete_ranked_ballots(min_cands=2, max_cands=25,
+                                        min_voters=1, max_voters=100))
+def test_top_n_irv_winner_in_range(election, tiebreaker):
+    n_cands = np.shape(election)[1]
+    w = top_n_irv(election, min(4, n_cands), tiebreaker)
+    assert w in range(n_cands)
+
+
+@given(election=complete_ranked_ballots(min_cands=2, max_cands=25,
+                                        min_voters=1, max_voters=100))
+def test_top_n_irv_winner_none_tiebreaker(election):
+    n_cands = np.shape(election)[1]
+    w = top_n_irv(election, min(4, n_cands))
+    assert w in {None} | set(range(n_cands))
+
+
+if __name__ == '__main__':
+    from subprocess import PIPE, Popen
+    with Popen(['pytest', '--tb=short', str(__file__)],
+               stdout=PIPE, bufsize=1, universal_newlines=True) as p:
+        for line in p.stdout:
+            print(line, end='')

--- a/tests/test_blanket_primary.py
+++ b/tests/test_blanket_primary.py
@@ -4,9 +4,7 @@ from hypothesis import given
 from hypothesis.strategies import integers, lists, permutations
 
 from elsim.methods import (approval_runoff, irv, irv_primary_top_n_runoff,
-                           runoff, top_five_condorcet, top_four_irv,
-                           top_four_runoff, top_five_irv, top_n_condorcet,
-                           top_n_irv, top_n_runoff)
+                           runoff, top_n_condorcet, top_n_irv, top_n_runoff)
 from elsim.methods.blanket_primary import (_head_to_head_two,
                                            _top_n_from_plurality_tallies)
 
@@ -20,27 +18,27 @@ def complete_ranked_ballots(min_cands=3, max_cands=256, min_voters=1,
 
 
 @pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
-def test_top_four_irv_tennessee(tiebreaker):
+def test_top_n_irv_four_and_five_tennessee(tiebreaker):
     Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
     election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
                 *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
                 *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
                 *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
                 ]
-    assert top_four_irv(election, tiebreaker) == Knoxville
-    assert top_five_irv(election, tiebreaker) == Knoxville
+    assert top_n_irv(election, 4, tiebreaker) == Knoxville
+    assert top_n_irv(election, 5, tiebreaker) == Knoxville
     assert irv(election, tiebreaker) == Knoxville
 
 
 @pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
-def test_top_four_runoff_tennessee(tiebreaker):
+def test_top_n_runoff_four_tennessee(tiebreaker):
     Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
     election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
                 *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
                 *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
                 *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
                 ]
-    assert top_four_runoff(election, tiebreaker) == runoff(
+    assert top_n_runoff(election, 4, tiebreaker) == runoff(
         election, tiebreaker)
 
 
@@ -56,28 +54,28 @@ def test_irv_primary_runoff_tennessee(tiebreaker):
         election, tiebreaker)
 
 
-def test_irv_n_survivors_three_cycle():
+def test_irv_n_winners_three_cycle():
     election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
-    assert irv(election, n_survivors=2) is None
-    assert sorted(irv(election, n_survivors=2, tiebreaker='order')) == [0, 1]
+    assert irv(election, n_winners=2) is None
+    assert sorted(irv(election, n_winners=2, tiebreaker='order')) == [0, 1]
 
 
-def test_irv_n_survivors_invalid_n():
-    with pytest.raises(ValueError, match='n_survivors must be at least 1'):
-        irv([[0, 1]], n_survivors=0)
+def test_irv_n_winners_invalid_n():
+    with pytest.raises(ValueError, match='n_winners must be at least 1'):
+        irv([[0, 1]], n_winners=0)
 
 
-def test_irv_n_survivors_all_survive_when_n_ge_total():
-    assert irv(np.array([[0, 1], [1, 0]]), n_survivors=2,
+def test_irv_n_winners_all_survive_when_n_ge_total():
+    assert irv(np.array([[0, 1], [1, 0]]), n_winners=2,
                 tiebreaker='order') == {0, 1}
 
 
-def test_irv_n_survivors_pre_elimination_zero_first_place():
+def test_irv_n_winners_pre_elimination_zero_first_place():
     election = np.array([[0, 1, 2, 3],
                          [0, 1, 2, 3],
                          [1, 0, 2, 3],
                          [1, 0, 2, 3]])
-    assert irv(election, n_survivors=2, tiebreaker='order') == {0, 1}
+    assert irv(election, n_winners=2, tiebreaker='order') == {0, 1}
 
 
 def test__top_n_from_plurality_tallies():
@@ -165,8 +163,9 @@ def test_top_n_condorcet_returns_none_on_cycle():
     assert top_n_condorcet(election, 3, tiebreaker='order') is None
 
 
-def test_top_five_condorcet_smoke():
-    assert top_five_condorcet([[0, 1], [0, 1], [1, 0]], tiebreaker='order') == 0
+def test_top_n_condorcet_five_smoke():
+    assert top_n_condorcet([[0, 1], [0, 1], [1, 0]], 5,
+                           tiebreaker='order') == 0
 
 
 def test_irv_primary_top_n_runoff_returns_none():
@@ -207,7 +206,7 @@ def test_blanket_methods_reject_invalid_tiebreaker():
     with pytest.raises(ValueError):
         top_n_condorcet(election, 2, tiebreaker='duel')
     with pytest.raises(ValueError):
-        irv(election, tiebreaker='duel', n_survivors=2)
+        irv(election, tiebreaker='duel', n_winners=2)
 
 
 @pytest.mark.parametrize('tiebreaker', ['random', 'order'])

--- a/tests/test_blanket_primary.py
+++ b/tests/test_blanket_primary.py
@@ -5,8 +5,11 @@ from hypothesis.strategies import integers, lists, permutations
 
 from elsim.methods import (approval_runoff, irv, irv_eliminate_to_n,
                            irv_primary_top_n_irv, irv_primary_top_n_runoff,
-                           runoff, top_four_irv, top_four_runoff, top_five_irv,
-                           top_n_condorcet, top_n_irv, top_n_runoff)
+                           runoff, top_five_condorcet, top_four_irv,
+                           top_four_runoff, top_five_irv, top_n_condorcet,
+                           top_n_irv, top_n_runoff)
+from elsim.methods.blanket_primary import (_head_to_head_two,
+                                           _top_n_from_plurality_tallies)
 
 
 def complete_ranked_ballots(min_cands=3, max_cands=256, min_voters=1,
@@ -59,6 +62,133 @@ def test_irv_eliminate_to_n_three_cycle():
     election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
     assert irv_eliminate_to_n(election, 2) is None
     assert sorted(irv_eliminate_to_n(election, 2, tiebreaker='order')) == [0, 1]
+
+
+def test_irv_eliminate_to_n_invalid_n():
+    with pytest.raises(ValueError, match='n must be at least 1'):
+        irv_eliminate_to_n([[0, 1]], 0)
+
+
+def test_irv_eliminate_to_n_all_survive_when_n_ge_total():
+    assert irv_eliminate_to_n(np.array([[0, 1], [1, 0]]), 2, 'order') == {0, 1}
+
+
+def test_irv_eliminate_to_n_pre_elimination_zero_first_place():
+    election = np.array([[0, 1, 2, 3],
+                         [0, 1, 2, 3],
+                         [1, 0, 2, 3],
+                         [1, 0, 2, 3]])
+    assert irv_eliminate_to_n(election, 2, tiebreaker='order') == {0, 1}
+
+
+def test__top_n_from_plurality_tallies():
+    with pytest.raises(ValueError, match='n must be at least 1'):
+        _top_n_from_plurality_tallies(np.array([1, 2]), 0, None)
+    assert _top_n_from_plurality_tallies(np.array([5, 4]), 2, None) == {0, 1}
+    assert _top_n_from_plurality_tallies(np.array([9, 4, 2, 1]), 2, None) == {0, 1}
+    assert _top_n_from_plurality_tallies(np.array([5, 5, 5, 5]), 2, None) is None
+
+
+def test__head_to_head_two():
+    e2 = np.array([[0, 1], [0, 1], [1, 0]])
+    assert _head_to_head_two(0, 1, e2, tiebreaker='order') == 0
+    assert _head_to_head_two(0, 1, np.array([[1, 0], [1, 0], [1, 0]]),
+                             tiebreaker='order') == 1
+    assert _head_to_head_two(0, 1, np.array([[0, 1], [1, 0]]),
+                             tiebreaker=None) is None
+
+
+def test_approval_runoff_primary_and_general_edges():
+    app = np.ones((4, 4), dtype=np.uint8)
+    ranked = np.array([[0, 1, 2, 3]] * 4)
+    assert approval_runoff(app, ranked, tiebreaker=None) is None
+
+    app_one = np.array([[1], [1]], dtype=np.uint8)
+    ranked_one = np.array([[0], [0]])
+    assert approval_runoff(app_one, ranked_one) == 0
+
+    with pytest.raises(ValueError, match='0 and 1'):
+        approval_runoff(np.array([[2, 0]], dtype=np.uint8),
+                         np.array([[0, 1]]))
+
+    app_tie = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    ranked_tie = np.array([[0, 1], [1, 0]])
+    assert approval_runoff(app_tie, ranked_tie, tiebreaker=None) is None
+
+
+def test_top_n_irv_primary_tie_returns_none():
+    first = np.array([0, 0, 0, 1, 1, 2, 2, 3])
+    rows = []
+    for fp in first:
+        tail = [c for c in range(4) if c != fp]
+        rows.append([fp, *tail])
+    election = np.array(rows)
+    assert top_n_irv(election, 2, tiebreaker=None) is None
+
+
+def test_top_n_irv_general_returns_none():
+    election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
+    assert top_n_irv(election, 3, tiebreaker=None) is None
+
+
+def test_top_n_runoff_returns_none_paths():
+    first = np.array([0, 0, 0, 1, 1, 2, 2, 3])
+    rows = []
+    for fp in first:
+        tail = [c for c in range(4) if c != fp]
+        rows.append([fp, *tail])
+    election = np.array(rows)
+    assert top_n_runoff(election, 2, tiebreaker=None) is None
+
+    election = np.array([[2, 0, 1],
+                         [0, 1, 2],
+                         [1, 0, 2],
+                         [2, 0, 1],
+                         [2, 1, 0],
+                         [0, 1, 2],
+                         [2, 0, 1],
+                         [1, 0, 2],
+                         [2, 1, 0],
+                         [0, 2, 1]])
+    assert runoff(election) is None
+    assert top_n_runoff(election, 3, None) is None
+
+
+def test_top_n_condorcet_primary_tie_returns_none():
+    first = np.array([0, 0, 0, 1, 1, 2, 2, 3])
+    rows = [[fp, *[c for c in range(4) if c != fp]] for fp in first]
+    election = np.array(rows)
+    assert top_n_condorcet(election, 2, tiebreaker=None) is None
+
+
+def test_top_n_condorcet_returns_none_on_cycle():
+    election = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
+    assert top_n_condorcet(election, 3, tiebreaker='order') is None
+
+
+def test_top_five_condorcet_smoke():
+    assert top_five_condorcet([[0, 1], [0, 1], [1, 0]], tiebreaker='order') == 0
+
+
+def test_irv_primary_top_n_returns_none():
+    assert irv_primary_top_n_irv([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 2,
+                                 tiebreaker=None) is None
+    assert irv_primary_top_n_irv([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 3,
+                                 tiebreaker=None) is None
+    assert irv_primary_top_n_runoff([[0, 1, 2], [1, 2, 0], [2, 0, 1]], 2,
+                                      tiebreaker=None) is None
+
+    election = np.array([[2, 0, 1],
+                         [0, 1, 2],
+                         [1, 0, 2],
+                         [2, 0, 1],
+                         [2, 1, 0],
+                         [0, 1, 2],
+                         [2, 0, 1],
+                         [1, 0, 2],
+                         [2, 1, 0],
+                         [0, 2, 1]])
+    assert irv_primary_top_n_runoff(election, 3, None) is None
 
 
 def test_approval_runoff_matches_head_to_head():

--- a/tests/test_blanket_primary.py
+++ b/tests/test_blanket_primary.py
@@ -6,6 +6,8 @@ from hypothesis.strategies import integers, lists, permutations
 from elsim.methods import (approval_runoff, irv, irv_primary_top_n_runoff,
                            runoff, top_n_condorcet, top_n_irv, top_n_runoff)
 from elsim.methods.blanket_primary import (_head_to_head_two,
+                                           _primary_top_n_approval,
+                                           _restrict_ballots,
                                            _top_n_from_plurality_tallies)
 
 
@@ -31,7 +33,7 @@ def test_top_n_irv_four_and_five_tennessee(tiebreaker):
 
 
 @pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
-def test_top_n_runoff_four_tennessee(tiebreaker):
+def test_top_n_runoff_four_and_five_tennessee(tiebreaker):
     Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
     election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
                 *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
@@ -40,10 +42,37 @@ def test_top_n_runoff_four_tennessee(tiebreaker):
                 ]
     assert top_n_runoff(election, 4, tiebreaker) == runoff(
         election, tiebreaker)
+    assert top_n_runoff(election, 5, tiebreaker) == runoff(
+        election, tiebreaker)
 
 
 @pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
-def test_irv_primary_runoff_tennessee(tiebreaker):
+def test_top_n_condorcet_tennessee(tiebreaker):
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert top_n_condorcet(election, 4, tiebreaker) == Nashville
+    assert top_n_condorcet(election, 5, tiebreaker) == Nashville
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_top_n_runoff_primary_narrows_field(tiebreaker):
+    """Top-three primary can change the contingent-vote finalists vs full runoff."""
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert top_n_runoff(election, 3, tiebreaker) == Knoxville
+    assert runoff(election, tiebreaker) == Nashville
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_irv_primary_runoff_four_and_five_tennessee(tiebreaker):
     Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
     election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
                 *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
@@ -52,6 +81,22 @@ def test_irv_primary_runoff_tennessee(tiebreaker):
                 ]
     assert irv_primary_top_n_runoff(election, 4, tiebreaker) == runoff(
         election, tiebreaker)
+    assert irv_primary_top_n_runoff(election, 5, tiebreaker) == runoff(
+        election, tiebreaker)
+
+
+@pytest.mark.parametrize('tiebreaker', [None, 'random', 'order'])
+def test_irv_primary_runoff_narrows_field(tiebreaker):
+    """IRV primary to two or three can pick different finalists than top-two."""
+    Memphis, Nashville, Chattanooga, Knoxville = 0, 1, 2, 3
+    election = [*42 * [[Memphis, Nashville, Chattanooga, Knoxville]],
+                *26 * [[Nashville, Chattanooga, Knoxville, Memphis]],
+                *15 * [[Chattanooga, Knoxville, Nashville, Memphis]],
+                *17 * [[Knoxville, Chattanooga, Nashville, Memphis]],
+                ]
+    assert irv_primary_top_n_runoff(election, 2, tiebreaker) == Knoxville
+    assert irv_primary_top_n_runoff(election, 3, tiebreaker) == Knoxville
+    assert runoff(election, tiebreaker) == Nashville
 
 
 def test_irv_n_winners_three_cycle():
@@ -84,6 +129,23 @@ def test__top_n_from_plurality_tallies():
     assert _top_n_from_plurality_tallies(np.array([5, 4]), 2, None) == {0, 1}
     assert _top_n_from_plurality_tallies(np.array([9, 4, 2, 1]), 2, None) == {0, 1}
     assert _top_n_from_plurality_tallies(np.array([5, 5, 5, 5]), 2, None) is None
+    assert _top_n_from_plurality_tallies(np.array([5, 5, 5, 5]), 2,
+                                         'order') == {0, 1}
+    assert _top_n_from_plurality_tallies(np.array([9, 4, 4, 1]), 3,
+                                         'order') == {0, 1, 2}
+
+
+def test__primary_top_n_approval():
+    app = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1]], dtype=np.uint8)
+    assert _primary_top_n_approval(app, 2, 'order') == {0, 1}
+    assert _primary_top_n_approval(app, 3, 'order') == {0, 1, 2}
+
+
+def test__restrict_ballots():
+    election = np.array([[0, 1, 2, 3], [3, 2, 1, 0]])
+    sub, new_to_old = _restrict_ballots(election, {0, 3})
+    assert sub.tolist() == [[0, 1], [1, 0]]
+    assert new_to_old == {0: 0, 1: 3}
 
 
 def test__head_to_head_two():
@@ -206,7 +268,23 @@ def test_blanket_methods_reject_invalid_tiebreaker():
     with pytest.raises(ValueError):
         top_n_condorcet(election, 2, tiebreaker='duel')
     with pytest.raises(ValueError):
+        irv_primary_top_n_runoff(election, 2, tiebreaker='duel')
+    with pytest.raises(ValueError):
         irv(election, tiebreaker='duel', n_winners=2)
+
+
+def test_docstring_examples():
+    A, B, C = 0, 1, 2
+    election = [*6 * [[A, B, C]], *3 * [[B, A, C]], *1 * [[C, B, A]]]
+    assert top_n_irv(election, 2) == 0
+    assert irv_primary_top_n_runoff(election, 2, tiebreaker='order') == 0
+
+    election2 = [[A, B, C], [A, B, C], [B, A, C]]
+    assert top_n_condorcet(election2, 2) == 0
+
+    approvals = [[1, 1, 0], [1, 1, 0], [0, 1, 1]]
+    ranked = [[B, A, C], [B, C, A], [C, B, A]]
+    assert approval_runoff(approvals, ranked) == 1
 
 
 @pytest.mark.parametrize('tiebreaker', ['random', 'order'])
@@ -223,6 +301,33 @@ def test_top_n_irv_winner_in_range(election, tiebreaker):
 def test_top_n_irv_winner_none_tiebreaker(election):
     n_cands = np.shape(election)[1]
     w = top_n_irv(election, min(4, n_cands))
+    assert w in {None} | set(range(n_cands))
+
+
+@pytest.mark.parametrize('method', [top_n_runoff, irv_primary_top_n_runoff])
+@pytest.mark.parametrize('tiebreaker', ['random', 'order'])
+@given(election=complete_ranked_ballots(min_cands=2, max_cands=25,
+                                        min_voters=1, max_voters=100))
+def test_blanket_runoff_variants_winner_in_range(election, method, tiebreaker):
+    n_cands = np.shape(election)[1]
+    w = method(election, min(4, n_cands), tiebreaker)
+    assert w in range(n_cands)
+
+
+@pytest.mark.parametrize('tiebreaker', ['random', 'order'])
+@given(election=complete_ranked_ballots(min_cands=2, max_cands=25,
+                                        min_voters=1, max_voters=100))
+def test_top_n_condorcet_winner_in_range_or_none(election, tiebreaker):
+    n_cands = np.shape(election)[1]
+    w = top_n_condorcet(election, min(4, n_cands), tiebreaker)
+    assert w in {None} | set(range(n_cands))
+
+
+@given(election=complete_ranked_ballots(min_cands=2, max_cands=25,
+                                        min_voters=1, max_voters=100))
+def test_top_n_runoff_winner_none_tiebreaker(election):
+    n_cands = np.shape(election)[1]
+    w = top_n_runoff(election, min(4, n_cands))
     assert w in {None} | set(range(n_cands))
 
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,7 +1,22 @@
 import pytest
 
-from elsim.methods import (approval, black, borda, combined_approval, coombs,
-                           fptp, irv, runoff, score, utility_winner)
+from elsim.methods import (approval, approval_runoff, black, borda,
+                           combined_approval, coombs, fptp, irv,
+                           irv_primary_top_n_irv, irv_primary_top_n_runoff,
+                           runoff, score, top_four_condorcet, top_four_irv,
+                           top_five_irv, top_four_runoff, top_five_runoff,
+                           top_n_condorcet, top_n_irv, top_n_runoff,
+                           utility_winner)
+
+_blanket_ranked = [
+    top_four_irv, top_five_irv, top_four_runoff, top_five_runoff,
+    lambda e, tb=None: irv_primary_top_n_irv(e, 4, tb),
+    lambda e, tb=None: irv_primary_top_n_runoff(e, 4, tb),
+    lambda e, tb=None: top_n_irv(e, 3, tb),
+    lambda e, tb=None: top_n_runoff(e, 3, tb),
+    lambda e, tb=None: top_n_condorcet(e, 3, tb),
+    top_four_condorcet,
+]
 
 
 @pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs,
@@ -14,7 +29,13 @@ def test_invalid_tiebreaker(method):
         method(election, tiebreaker='duel')
 
 
-@pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs])
+def test_invalid_tiebreaker_approval_runoff():
+    with pytest.raises(ValueError):
+        approval_runoff([[1, 0]], [[0, 1]], tiebreaker='duel')
+
+
+@pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs,
+                                    *_blanket_ranked])
 def test_ranked_method_degenerate_case(method):
     election = [[0]]
     assert method(election) == 0
@@ -27,7 +48,8 @@ def test_ranked_method_degenerate_case(method):
     assert method(election, 'order') == 0
 
 
-@pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs])
+@pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs,
+                                    *_blanket_ranked])
 def test_ranked_method_unanimity(method):
     election = [[3, 0, 1, 2], [3, 0, 2, 1], [3, 2, 1, 0]]
     assert method(election) == 3

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -3,17 +3,19 @@ import pytest
 from elsim.methods import (approval, approval_runoff, black, borda,
                            combined_approval, coombs, fptp, irv,
                            irv_primary_top_n_runoff, runoff, score,
-                           top_four_condorcet, top_four_irv, top_five_irv,
-                           top_four_runoff, top_five_runoff, top_n_condorcet,
-                           top_n_irv, top_n_runoff, utility_winner)
+                           top_n_condorcet, top_n_irv, top_n_runoff,
+                           utility_winner)
 
 _blanket_ranked = [
-    top_four_irv, top_five_irv, top_four_runoff, top_five_runoff,
+    lambda e, tb=None: top_n_irv(e, 4, tb),
+    lambda e, tb=None: top_n_irv(e, 5, tb),
+    lambda e, tb=None: top_n_runoff(e, 4, tb),
+    lambda e, tb=None: top_n_runoff(e, 5, tb),
     lambda e, tb=None: irv_primary_top_n_runoff(e, 4, tb),
     lambda e, tb=None: top_n_irv(e, 3, tb),
     lambda e, tb=None: top_n_runoff(e, 3, tb),
     lambda e, tb=None: top_n_condorcet(e, 3, tb),
-    top_four_condorcet,
+    lambda e, tb=None: top_n_condorcet(e, 4, tb),
 ]
 
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -2,15 +2,13 @@ import pytest
 
 from elsim.methods import (approval, approval_runoff, black, borda,
                            combined_approval, coombs, fptp, irv,
-                           irv_primary_top_n_irv, irv_primary_top_n_runoff,
-                           runoff, score, top_four_condorcet, top_four_irv,
-                           top_five_irv, top_four_runoff, top_five_runoff,
-                           top_n_condorcet, top_n_irv, top_n_runoff,
-                           utility_winner)
+                           irv_primary_top_n_runoff, runoff, score,
+                           top_four_condorcet, top_four_irv, top_five_irv,
+                           top_four_runoff, top_five_runoff, top_n_condorcet,
+                           top_n_irv, top_n_runoff, utility_winner)
 
 _blanket_ranked = [
     top_four_irv, top_five_irv, top_four_runoff, top_five_runoff,
-    lambda e, tb=None: irv_primary_top_n_irv(e, 4, tb),
     lambda e, tb=None: irv_primary_top_n_runoff(e, 4, tb),
     lambda e, tb=None: top_n_irv(e, 3, tb),
     lambda e, tb=None: top_n_runoff(e, 3, tb),

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -12,10 +12,12 @@ _blanket_ranked = [
     lambda e, tb=None: top_n_runoff(e, 4, tb),
     lambda e, tb=None: top_n_runoff(e, 5, tb),
     lambda e, tb=None: irv_primary_top_n_runoff(e, 4, tb),
+    lambda e, tb=None: irv_primary_top_n_runoff(e, 5, tb),
     lambda e, tb=None: top_n_irv(e, 3, tb),
     lambda e, tb=None: top_n_runoff(e, 3, tb),
     lambda e, tb=None: top_n_condorcet(e, 3, tb),
     lambda e, tb=None: top_n_condorcet(e, 4, tb),
+    lambda e, tb=None: top_n_condorcet(e, 5, tb),
 ]
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #17.

## Summary

Adds `elsim.methods.blanket_primary` with two-round reform methods:

| Method | Primary | General |
|--------|---------|---------|
| `approval_runoff` | Top-two approval (Unified Primary) | Contingent vote on ranked ballots |
| `top_n_irv` | Top-`n` first preferences (`sntv`) | IRV among finalists |
| `top_n_runoff` | Top-`n` first preferences | Contingent vote among finalists |
| `top_n_condorcet` | Top-`n` first preferences | Condorcet among finalists |
| `irv_primary_top_n_runoff` | `irv(..., n_winners=n)` | Contingent vote among finalists |

Also extends `irv` with `n_winners=...` for ranked primaries that eliminate to a slate without majority short-circuit.

API uses `top_n_*` with `n=4` (Top Four) or `n=5` (Final Five) rather than separate `top_four_*` / `top_five_*` wrappers. Docstrings use **Unified Primary**, **Top Four**, and **Final Five** naming and describe the general election as a contingent vote where applicable.

## Tests

- 262 tests pass (CI green).
- New review-pass coverage: Tennessee benchmarks for all variants (including `n=5`), semantic regressions showing primary narrowing can change outcomes vs plain `runoff`, helper unit tests, docstring examples, and hypothesis property tests for `top_n_runoff`, `top_n_condorcet`, and `irv_primary_top_n_runoff`.

## Human review checklist

### API & naming
- [ ] Public exports in `elsim.methods.__init__` match intended surface (`approval_runoff`, `top_n_irv`, `top_n_runoff`, `top_n_condorcet`, `irv_primary_top_n_runoff`).
- [ ] `top_n_*` + `n=4` / `n=5` naming is clear enough vs Alaska Top Four / Final Five reform packages.
- [ ] `irv(..., n_winners=k)` keyword-only API and return type (`int` vs `set` vs `None`) read correctly in docs.

### Electoral semantics
- [ ] **Unified Primary** (`approval_runoff`): top-two by approval tallies, then pairwise majority on ranked ballots (contingent vote).
- [ ] **Top-`n` plurality primary** (`top_n_irv`, `top_n_runoff`, `top_n_condorcet`): same `sntv` rule as existing `sntv`; ballots restricted to finalists before the general.
- [ ] **`top_n_runoff` ≠ `runoff`**: general counts first preferences among finalists only (see Tennessee `n=3` test: Knoxville vs Nashville).
- [ ] **`irv_primary_top_n_runoff`**: primary is IRV elimination to `n` survivors (no majority stop); general is contingent vote on restricted ballots.
- [ ] **`top_n_condorcet` general**: no tiebreaker in Condorcet stage (matches `condorcet`); returns `None` on cycles.

### Tie-breaking
- [ ] Primary-stage ties use `order` / `random` / `None` consistently with `sntv` and `irv`.
- [ ] `approval_runoff` breaks primary and general ties via the same `tiebreaker` argument.
- [ ] Unbroken ties return `None` (not an arbitrary winner).

### Docs & references
- [ ] Wikipedia / FairVote / Alaska / Delemazure citations are appropriate and links resolve.
- [ ] Docstrings distinguish contingent vote from supplementary vote where relevant.
- [ ] Doctests / examples in docstrings match implementation.

### Edge cases
- [ ] Single-candidate and degenerate elections (`test_methods` unanimity / single-candidate).
- [ ] `n >= n_candidates` advances everyone without error.
- [ ] Invalid approval ballots (`max > 1`) and row-count mismatch raise `ValueError`.
- [ ] `n_winners < 1` raises `ValueError`.

### Code quality
- [ ] `_restrict_ballots` remaps candidate IDs correctly when finalists are a non-contiguous subset.
- [ ] No unnecessary duplication with `runoff` / `irv` / `condorcet` internals.
- [ ] Import style (relative imports in `__init__.py`) matches project preference.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a6e3629-1ec5-46fc-82b7-242b74e2cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a6e3629-1ec5-46fc-82b7-242b74e2cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

