### PR TITLE
runoff: reuse IRV Numba tally helpers for head-to-head round

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: [--maxkb=2048]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.16
     hooks:
       # Quote --select=...: in YAML flow style, commas inside [...] split list items (E902 on Windows).
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: [--maxkb=2048]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.15
     hooks:
       # Quote --select=...: in YAML flow style, commas inside [...] split list items (E902 on Windows).
       - id: ruff

--- a/elsim/methods/runoff.py
+++ b/elsim/methods/runoff.py
@@ -1,7 +1,14 @@
 import numpy as np
 
-from elsim.methods._common import (_all_indices, _get_tiebreak, _no_tiebreak,
-                                   _order_tiebreak_keep, _random_tiebreak)
+from elsim.methods._common import (
+    _all_indices,
+    _get_tiebreak,
+    _inc_rank_idx,
+    _no_tiebreak,
+    _order_tiebreak_keep,
+    _random_tiebreak,
+    _tally_at_rank_idx,
+)
 
 _tiebreak_map = {'order': _order_tiebreak_keep,
                  'random': _random_tiebreak,
@@ -93,19 +100,18 @@ def runoff(election, tiebreaker=None):
     if None in finalists:
         return None
 
-    # TODO: Can this be vectorized or numbafied?
     finalist_0 = finalists[0]
     finalist_1 = finalists[1]
 
-    finalist_0_tally = 0
-    finalist_1_tally = 0
-
-    for ballot in election:
-        ballot_list = ballot.tolist()
-        if ballot_list.index(finalist_0) < ballot_list.index(finalist_1):
-            finalist_0_tally += 1
-        else:
-            finalist_1_tally += 1
+    n_cands = election.shape[1]
+    cand_tallies = np.empty(n_cands, dtype=np.uint)
+    voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
+    eliminated_cands = set(range(n_cands)) - {finalist_0, finalist_1}
+    if eliminated_cands:
+        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+    _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+    finalist_0_tally = cand_tallies[finalist_0]
+    finalist_1_tally = cand_tallies[finalist_1]
 
     assert finalist_0_tally + finalist_1_tally == n_voters
 

--- a/elsim/methods/runoff.py
+++ b/elsim/methods/runoff.py
@@ -106,9 +106,10 @@ def runoff(election, tiebreaker=None):
     n_cands = election.shape[1]
     cand_tallies = np.empty(n_cands, dtype=np.uint)
     voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
-    eliminated_cands = set(range(n_cands)) - {finalist_0, finalist_1}
-    if eliminated_cands:
-        _inc_rank_idx(election, voter_top_rank_idx, eliminated_cands)
+    eliminated_mask = np.ones(n_cands, dtype=bool)
+    eliminated_mask[finalist_0] = False
+    eliminated_mask[finalist_1] = False
+    _inc_rank_idx(election, voter_top_rank_idx, eliminated_mask)
     _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
     finalist_0_tally = cand_tallies[finalist_0]
     finalist_1_tally = cand_tallies[finalist_1]

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -6,6 +6,7 @@ from hypothesis import given
 from hypothesis.strategies import integers, lists, permutations
 
 from elsim.methods import runoff
+from elsim.methods._common import _inc_rank_idx, _tally_at_rank_idx
 
 
 def collect_random_results(method, election):
@@ -20,6 +21,41 @@ def collect_random_results(method, election):
         assert isinstance(winner, int)
         winners.add(winner)
     return winners
+
+
+def test_docstring_example():
+    """Contingent vote example from runoff() docstring."""
+    A, B, C = 0, 1, 2
+    election = np.array([[A, C, B],
+                         [A, C, B],
+                         [B, C, A],
+                         [B, C, A],
+                         [C, A, B]])
+    assert runoff(election) == A
+
+
+def test_head_to_head_tally_via_irv_helpers():
+    """
+    Second-round tally skips eliminated candidates then counts top preference
+    among the two finalists (same path as IRV).
+    """
+    A, B, C = 0, 1, 2
+    election = np.array([[A, C, B],
+                         [A, C, B],
+                         [B, C, A],
+                         [B, C, A],
+                         [C, A, B]])
+    n_voters, n_cands = election.shape
+    voter_top_rank_idx = np.zeros(n_voters, dtype=np.uint8)
+    cand_tallies = np.empty(n_cands, dtype=np.uint)
+    eliminated_mask = np.ones(n_cands, dtype=bool)
+    eliminated_mask[A] = False
+    eliminated_mask[B] = False
+    _inc_rank_idx(election, voter_top_rank_idx, eliminated_mask)
+    _tally_at_rank_idx(cand_tallies, election, voter_top_rank_idx)
+    assert cand_tallies[A] == 3
+    assert cand_tallies[B] == 2
+    assert cand_tallies[C] == 0
 
 
 def test_one_round():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3.

## Summary

The contingent-vote / top-two runoff second round used a Python loop with `list.index` per ballot. That round is equivalent to instant runoff among only the two finalists: skip every other candidate on each ballot, then count first preference among `{finalist_0, finalist_1}`. That is exactly what `_inc_rank_idx` + `_tally_at_rank_idx` do—the same Numba path IRV and Coombs use.

## Changes

**`elsim/methods/runoff.py`**
- Replace the per-ballot `list.index` head-to-head tally with `_inc_rank_idx` / `_tally_at_rank_idx`.
- Build an `eliminated_mask` (all candidates except the two finalists) and advance each voter's rank cursor past eliminated candidates before tallying.
- Uses the same boolean-mask API as IRV/Coombs after master dropped reflected Python `set` in Numba helpers.

**`tests/test_runoff.py`**
- `test_docstring_example`: exercises the contingent-vote example from the `runoff()` docstring.
- `test_head_to_head_tally_via_irv_helpers`: asserts the shared helpers produce the expected 3–2 split when only finalists A and B remain.

## Rebase notes

Rebased onto current `master`. The original PR passed a Python `set` into `_inc_rank_idx`; master now requires a boolean `eliminated_mask` ndarray, so the second commit updates runoff accordingly.

## Testing

- `pytest`: 217 passed locally (with `[fast]` / Numba).
- Existing runoff property tests (Hypothesis) unchanged and still pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2a7aed6-1d18-4469-96ce-b68f3132c8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2a7aed6-1d18-4469-96ce-b68f3132c8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

