### PR TITLE
Issue #20: bimodal winner distributions, 3-2-1, partisan primaries, Score/STAR ranges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: [--maxkb=2048]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.16
     hooks:
       # Quote --select=...: in YAML flow style, commas inside [...] split list items (E902 on Windows).
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: [--maxkb=2048]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.15
     hooks:
       # Quote --select=...: in YAML flow style, commas inside [...] split list items (E902 on Windows).
       - id: ruff

--- a/elsim/elections.py
+++ b/elsim/elections.py
@@ -311,20 +311,20 @@ def bimodal_electorate(n_voters_each, n_cands_each, dims=2, corr=0.0, disp=1.0,
 
     left_v, left_c = normal_electorate(n_voters_each, n_cands_each, dims=dims,
                                        corr=corr, disp=disp, random_state=rng)
-    left_v = np.asarray(left_v).copy()
-    left_c = np.asarray(left_c).copy()
+    left_v = _np.asarray(left_v).copy()
+    left_c = _np.asarray(left_c).copy()
     left_v[:, 0] -= separation
     left_c[:, 0] -= separation
 
     right_v, right_c = normal_electorate(n_voters_each, n_cands_each, dims=dims,
                                          corr=corr, disp=disp, random_state=rng)
-    right_v = np.asarray(right_v).copy()
-    right_c = np.asarray(right_c).copy()
+    right_v = _np.asarray(right_v).copy()
+    right_c = _np.asarray(right_c).copy()
     right_v[:, 0] += separation
     right_c[:, 0] += separation
 
-    voters = np.vstack((left_v, right_v))
-    cands = np.vstack((left_c, right_c))
+    voters = _np.vstack((left_v, right_v))
+    cands = _np.vstack((left_c, right_c))
 
     return voters, cands
 

--- a/elsim/elections.py
+++ b/elsim/elections.py
@@ -264,6 +264,71 @@ def normal_electorate(n_voters, n_cands, dims=2, corr=0.0, disp=1.0,
     return voters, candidates
 
 
+def bimodal_electorate(n_voters_each, n_cands_each, dims=2, corr=0.0, disp=1.0,
+                       separation=0.5, random_state=None):
+    """
+    Generate two-party spatial electorate and candidates (two clusters).
+
+    Voters and candidates are drawn in two equal groups. The first group is
+    centered at ``-separation`` and the second at ``+separation`` on the first
+    dimension (after the same correlation/scaling transform as
+    :func:`normal_electorate`). This matches a simple two-mode voter model (for
+    example two partisan bases at ±0.5 on a left–right axis when
+    ``separation`` is 0.5).
+
+    Convention for downstream partisan simulations: candidate indices ``0 ..``
+    ``n_cands_each - 1`` belong to the first cluster ("left"), and
+    ``n_cands_each .. 2 * n_cands_each - 1`` to the second ("right"). Voter
+    indices ``0 .. n_voters_each - 1`` are left-cluster voters;
+    ``n_voters_each .. 2 * n_voters_each - 1`` are right-cluster voters.
+
+    Parameters
+    ----------
+    n_voters_each : int
+        Number of voters in each cluster (total voters ``2 * n_voters_each``).
+    n_cands_each : int
+        Number of candidates per cluster (total candidates ``2 * n_cands_each``).
+    dims : int
+        Number of dimensions (same meaning as in :func:`normal_electorate`).
+    corr : float
+        Correlation between dimensions (same meaning as in :func:`normal_electorate`).
+    disp : float
+        Relative dispersion of candidates vs voters (same meaning as in
+        :func:`normal_electorate`).
+    separation : float
+        Distance along the first axis between the two cluster centers.
+    random_state : {None, int, np.random.Generator}, optional
+        Same as :func:`normal_electorate`.
+
+    Returns
+    -------
+    voters : numpy.ndarray
+        Shape ``(2 * n_voters_each, dims)``.
+    cands : numpy.ndarray
+        Shape ``(2 * n_cands_each, dims)``.
+    """
+    rng = _check_random_state(random_state)
+
+    left_v, left_c = normal_electorate(n_voters_each, n_cands_each, dims=dims,
+                                       corr=corr, disp=disp, random_state=rng)
+    left_v = np.asarray(left_v).copy()
+    left_c = np.asarray(left_c).copy()
+    left_v[:, 0] -= separation
+    left_c[:, 0] -= separation
+
+    right_v, right_c = normal_electorate(n_voters_each, n_cands_each, dims=dims,
+                                         corr=corr, disp=disp, random_state=rng)
+    right_v = np.asarray(right_v).copy()
+    right_c = np.asarray(right_c).copy()
+    right_v[:, 0] += separation
+    right_c[:, 0] += separation
+
+    voters = np.vstack((left_v, right_v))
+    cands = np.vstack((left_c, right_c))
+
+    return voters, cands
+
+
 def normed_dist_utilities(voters, cands):
     """
     Generate normalized utilities from a spatial model.

--- a/elsim/methods/__init__.py
+++ b/elsim/methods/__init__.py
@@ -12,15 +12,24 @@ from elsim.methods.condorcet import (condorcet, condorcet_from_matrix,
 from elsim.methods.coombs import coombs
 from elsim.methods.fptp import fptp, sntv
 from elsim.methods.irv import irv
+from elsim.methods.partisan_primaries import (
+    closed_partisan_primary_runoff,
+    nominee_restricted_plurality,
+    open_partisan_primary,
+    pairwise_majority_from_rankings,
+    top_two_runoff_reduced_turnout,
+)
 from elsim.methods.runoff import runoff
 from elsim.methods.score import score
 from elsim.methods.star import matrix_from_scores, star
+from elsim.methods.three_two_one import three_two_one
 from elsim.methods.utility_winner import utility_winner
 
 __all__ = [
     'approval',
     'black',
     'borda',
+    'closed_partisan_primary_runoff',
     'combined_approval',
     'condorcet',
     'condorcet_from_matrix',
@@ -28,10 +37,15 @@ __all__ = [
     'fptp',
     'irv',
     'matrix_from_scores',
+    'nominee_restricted_plurality',
+    'open_partisan_primary',
+    'pairwise_majority_from_rankings',
     'ranked_election_to_matrix',
     'runoff',
     'sntv',
     'score',
     'star',
+    'three_two_one',
+    'top_two_runoff_reduced_turnout',
     'utility_winner',
 ]

--- a/elsim/methods/partisan_primaries.py
+++ b/elsim/methods/partisan_primaries.py
@@ -1,0 +1,218 @@
+"""Two-party primary-style tallies for spatial simulations."""
+import numpy as np
+
+from elsim.methods._common import (_get_tiebreak, _no_tiebreak,
+                                   _order_tiebreak_keep, _random_tiebreak)
+from elsim.methods.fptp import sntv
+
+_tiebreak_map = {'order': _order_tiebreak_keep,
+                 'random': _random_tiebreak,
+                 None: _no_tiebreak}
+
+
+def nominee_restricted_plurality(rankings, voter_indices, allowed_candidates,
+                                 tiebreaker=None):
+    """
+    Plurality winner restricted to candidates in ``allowed_candidates``.
+
+    Each voter contributes one vote to their highest-ranked candidate among the
+    allowed set (same order as on their full ranking).
+
+    Parameters
+    ----------
+    rankings : array_like
+        Full ranked ballots, shape ``(n_voters, n_cands)``.
+    voter_indices : array_like
+        Indices of voters participating in this round (e.g. primary electorate).
+    allowed_candidates : array_like
+        Candidate IDs allowed on this ballot.
+
+    tiebreaker : {'random', 'order', None}, optional
+        Breaks ties for first place.
+
+    Returns
+    -------
+    winner : int
+        Candidate ID of the nominee.
+    """
+    rankings = np.asarray(rankings)
+    allowed_candidates = np.asarray(allowed_candidates, dtype=np.int64)
+    tallies = np.zeros(rankings.shape[1], dtype=np.int64)
+    allowed_set = frozenset(int(x) for x in allowed_candidates.flat)
+
+    for i in voter_indices:
+        for c in rankings[i]:
+            cc = int(c)
+            if cc in allowed_set:
+                tallies[cc] += 1
+                break
+
+    sub = tallies[allowed_candidates]
+    winners_rel = np.flatnonzero(sub == np.max(sub))
+    winners = allowed_candidates[winners_rel].tolist()
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
+    return tiebreak(winners)[0]
+
+
+def pairwise_majority_from_rankings(rankings, voter_indices, cand_a, cand_b,
+                                    tiebreaker=None):
+    """
+    Majority winner between two candidates using relative ranking order.
+
+    Parameters
+    ----------
+    rankings : array_like
+        Full rankings.
+    voter_indices : array_like
+        Voters participating in this comparison (e.g. general-election turnout).
+    cand_a, cand_b : int
+        Candidate IDs.
+
+    tiebreaker : {'random', 'order', None}, optional
+        Used when exactly half prefer each candidate.
+
+    Returns
+    -------
+    winner : int
+    """
+    rankings = np.asarray(rankings)
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
+    tally_a = 0
+    tally_b = 0
+
+    for i in voter_indices:
+        ballot = rankings[i]
+        pos_a = np.argmax(ballot == cand_a)
+        pos_b = np.argmax(ballot == cand_b)
+        if pos_a < pos_b:
+            tally_a += 1
+        elif pos_b < pos_a:
+            tally_b += 1
+
+    if tally_a > tally_b:
+        return cand_a
+    if tally_b > tally_a:
+        return cand_b
+    return tiebreak([cand_a, cand_b])[0]
+
+
+def open_partisan_primary(rankings, n_cands_left_cluster,
+                          primary_left_voters, primary_right_voters,
+                          general_voters, tiebreaker=None):
+    """
+    Open partisan primary then general election (both plurality).
+
+    Each party holds a primary among its own candidates using only that party's
+    primary electorate; the winners face each other in a general election using
+    ``general_voters``.
+
+    Candidate IDs ``0 .. n_cands_left_cluster - 1`` are the left party;
+    ``n_cands_left_cluster .. n_cands - 1`` are the right party.
+
+    Parameters
+    ----------
+    rankings : array_like
+        Honest full rankings for all voters.
+    n_cands_left_cluster : int
+        Number of candidates in the left party.
+    primary_left_voters, primary_right_voters : array_like
+        Voter indices participating in each party's primary (often subsets).
+    general_voters : array_like
+        Voter indices in the general election.
+
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : int
+        Winning candidate ID.
+    """
+    rankings = np.asarray(rankings)
+    n_cands = rankings.shape[1]
+    left_c = np.arange(0, n_cands_left_cluster)
+    right_c = np.arange(n_cands_left_cluster, n_cands)
+
+    nom_l = nominee_restricted_plurality(rankings, primary_left_voters,
+                                         left_c, tiebreaker)
+    nom_r = nominee_restricted_plurality(rankings, primary_right_voters,
+                                         right_c, tiebreaker)
+
+    return pairwise_majority_from_rankings(rankings, general_voters,
+                                           nom_l, nom_r, tiebreaker)
+
+
+def closed_partisan_primary_runoff(rankings, n_cands_left_cluster,
+                                   primary_left_voters, primary_right_voters,
+                                   runoff_voters, tiebreaker=None):
+    """
+    Closed partisan primaries followed by a top-two runoff.
+
+    Same primaries as :func:`open_partisan_primary`, but the contest between
+    nominees uses only ``runoff_voters`` (can be a subset of all voters).
+
+    Parameters
+    ----------
+    rankings : array_like
+    n_cands_left_cluster : int
+    primary_left_voters, primary_right_voters : array_like
+    runoff_voters : array_like
+        Voters participating in the general/runoff between nominees.
+
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : int
+    """
+    rankings = np.asarray(rankings)
+    n_cands = rankings.shape[1]
+    left_c = np.arange(0, n_cands_left_cluster)
+    right_c = np.arange(n_cands_left_cluster, n_cands)
+
+    nom_l = nominee_restricted_plurality(rankings, primary_left_voters,
+                                         left_c, tiebreaker)
+    nom_r = nominee_restricted_plurality(rankings, primary_right_voters,
+                                         right_c, tiebreaker)
+
+    return pairwise_majority_from_rankings(rankings, runoff_voters,
+                                           nom_l, nom_r, tiebreaker)
+
+
+def top_two_runoff_reduced_turnout(rankings, first_round_voters,
+                                   runoff_voters, tiebreaker=None):
+    """
+    Top-two runoff where the pairwise round uses a subset of voters.
+
+    The top two candidates by first-preference plurality among
+    ``first_round_voters`` advance; the winner is decided by pairwise majority
+    among ``runoff_voters``.
+
+    Parameters
+    ----------
+    rankings : array_like
+    first_round_voters : array_like
+        Voters counted for establishing the top two (general-election cohort).
+    runoff_voters : array_like
+        Usually a subset of voters for the second round.
+
+    tiebreaker : {'random', 'order', None}, optional
+
+    Returns
+    -------
+    winner : int
+    """
+    rankings = np.asarray(rankings)
+    first_prefs = rankings[first_round_voters, 0]
+    top_two = sntv(first_prefs, n=2, tiebreaker=tiebreaker)
+    if top_two is None:
+        return None
+
+    finalists = sorted(top_two)
+    if len(finalists) == 1:
+        return finalists[0]
+    if len(finalists) != 2:
+        return None
+
+    a, b = finalists[0], finalists[1]
+    return pairwise_majority_from_rankings(rankings, runoff_voters,
+                                           a, b, tiebreaker)

--- a/elsim/methods/three_two_one.py
+++ b/elsim/methods/three_two_one.py
@@ -1,0 +1,106 @@
+"""
+3-2-1 voting (Jameson Quinn).
+
+Ballots use integer ratings 0 = Bad, 1 = OK, 2 = Good per candidate.
+"""
+import numpy as np
+
+from elsim.methods._common import (_get_tiebreak, _no_tiebreak,
+                                   _order_tiebreak_keep, _random_tiebreak)
+
+_tiebreak_map = {'order': _order_tiebreak_keep,
+                 'random': _random_tiebreak,
+                 None: _no_tiebreak}
+
+
+def _pairwise_rating_preference(election, a, b, tiebreaker):
+    """
+    Winner between candidates ``a`` and ``b`` where higher rating wins each ballot.
+
+    Ties on the same ballot count toward neither side. Overall ties use total
+    rating points (Good=2, OK=1, Bad=0), then ``tiebreaker``.
+    """
+    ea = election[:, a]
+    eb = election[:, b]
+    a_strict = (ea > eb).sum()
+    b_strict = (eb > ea).sum()
+    if a_strict > b_strict:
+        return a
+    if b_strict > a_strict:
+        return b
+    sa = ea.sum()
+    sb = eb.sum()
+    if sa > sb:
+        return a
+    if sb > sa:
+        return b
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
+    return tiebreak([a, b])[0]
+
+
+def three_two_one(election, tiebreaker=None):
+    """
+    Find the winner using 3-2-1 voting.
+
+    Semifinalists are the three candidates with the most Good ratings; ties are
+    broken by total score (Good=2, OK=1). Among those three, the one with the
+    most Bad ratings is eliminated (ties broken by lower total score, then lower
+    candidate ID). The remaining two are compared pairwise by higher rating on
+    each ballot. [1]_
+
+    Party-specific rules for the third semifinalist and blank ballots from the
+    full specification are omitted here (they are optional for one-off
+    simulations).
+
+    Parameters
+    ----------
+    election : array_like
+        Shape ``(n_voters, n_candidates)``. Ratings must be 0, 1, or 2.
+
+    tiebreaker : {'random', 'order', None}, optional
+        Used whenever the rules leave a tie after score comparisons.
+
+    Returns
+    -------
+    winner : {int, None}
+
+    References
+    ----------
+    .. [1] https://electowiki.org/wiki/3-2-1_voting
+
+    """
+    election = np.asarray(election)
+
+    if election.ndim != 2:
+        raise ValueError('Election must be a 2D array')
+    if election.min() < 0 or election.max() > 2:
+        raise ValueError('3-2-1 ballots must use ratings 0, 1, and 2 only')
+
+    n_voters, n_cands = election.shape
+    tiebreak = _get_tiebreak(tiebreaker, _tiebreak_map)
+
+    good = (election == 2).sum(axis=0)
+    score = election.sum(axis=0)
+
+    if n_cands == 1:
+        return 0
+
+    if n_cands == 2:
+        return _pairwise_rating_preference(election, 0, 1, tiebreaker)
+
+    semifinalists = sorted(range(n_cands),
+                           key=lambda i: (-int(good[i]), -int(score[i]), i))[:3]
+
+    sf = semifinalists
+    bad_sf = [(election[:, j] == 0).sum() for j in sf]
+
+    mx_bad = max(bad_sf)
+    tied_max = [r for r in range(3) if bad_sf[r] == mx_bad]
+    elim_rel = sorted(tied_max, key=lambda r: (score[sf[r]], sf[r]))[0]
+
+    finalists = [sf[i] for i in range(3) if i != elim_rel]
+    if len(finalists) != 2:
+        raise RuntimeError('expected two finalists')
+
+    a, b = finalists[0], finalists[1]
+    return _pairwise_rating_preference(election, a, b, tiebreaker)

--- a/elsim/strategies.py
+++ b/elsim/strategies.py
@@ -63,7 +63,7 @@ def honest_rankings(utilities):
     return _np.argsort(utilities)[:, ::-1].astype(_np.uint8)
 
 
-def honest_normed_scores(utilities, max_score=5):
+def honest_normed_scores(utilities, max_score=5, *, min_score=0):
     """
     Convert utilities into scores using honest (but normalized) strategy.
 
@@ -81,8 +81,10 @@ def honest_normed_scores(utilities, max_score=5):
         voter.
 
     max_score : int, optional
-        The highest score on the ballot. If `max_score` = 3, the possible
-        scores are 0, 1, 2, 3.
+        The highest score on the ballot (inclusive).
+    min_score : int, optional
+        The lowest score on the ballot (inclusive). Use keyword syntax;
+        the second positional argument is always ``max_score``.
 
     Returns
     -------
@@ -113,22 +115,84 @@ def honest_normed_scores(utilities, max_score=5):
            [0, 5, 5]], dtype=uint8)
 
     """
+    if min_score > max_score:
+        raise ValueError('min_score cannot exceed max_score')
+
     # Slide every voter's minimum utility to 0
     normed = utilities - _np.amin(utilities, axis=1)[:, _np.newaxis]
 
     # If a ballot is all 0, suppress 0/0 warning.
     # astype(_np.uint8) will convert NaN back to 0.
+    span = max_score - min_score
     with _np.errstate(invalid='ignore'):
         # Normalize every voter's maximum utility to 1
         normed /= _np.amax(normed, axis=1)[:, _np.newaxis]
 
-        # Normalize every voter's maximum score to max_score
-        normed *= max_score
+        # Map [0, 1] to [min_score, max_score]
+        normed *= span
+        normed += min_score
 
         scores = _np.around(normed).astype(_np.uint8)
 
+    scores = _np.clip(scores, min_score, max_score)
+
+    no_pref = _np.ptp(utilities, axis=1) == 0
+    scores[no_pref] = _np.uint8(min_score)
+
     # Quantize to discrete scale
     return scores
+
+
+def honest_321_ratings(utilities):
+    """
+    Convert utilities to Good / OK / Bad ratings for 3-2-1 voting.
+
+    For each voter, candidates in the lowest third of utility (for that voter)
+    are rated Bad (0), the highest third Good (2), and the remainder OK (1).
+
+    Parameters
+    ----------
+    utilities : array_like
+        Same shape as for :func:`honest_rankings`.
+
+    Returns
+    -------
+    ratings : ndarray
+        Shape matching ``utilities``, dtype uint8, values 0 (Bad), 1 (OK),
+        2 (Good).
+
+    Examples
+    --------
+    >>> utilities = [[1.0, 0.5, 0.0],
+    ...              [0.0, 0.3, 1.0]]
+    >>> honest_321_ratings(utilities)
+    array([[2, 1, 0],
+           [0, 1, 2]], dtype=uint8)
+    """
+    utilities = _np.asarray(utilities)
+    n_voters, n_cands = utilities.shape
+    if n_cands > 255:
+        raise ValueError('Maximum number of candidates is 255')
+
+    ratings = _np.ones((n_voters, n_cands), dtype=_np.uint8)
+    order = _np.argsort(utilities, axis=1)
+
+    if n_cands == 1:
+        ratings[:] = 2
+        return ratings
+
+    if n_cands == 2:
+        for i in range(n_voters):
+            ratings[i, order[i, 0]] = 0
+            ratings[i, order[i, 1]] = 2
+        return ratings
+
+    n_bad = n_cands // 3
+    n_good = n_cands // 3
+    for i in range(n_voters):
+        ratings[i, order[i, :n_bad]] = 0
+        ratings[i, order[i, n_cands - n_good:]] = 2
+    return ratings
 
 
 def approval_optimal(utilities):
@@ -277,6 +341,7 @@ def vote_for_k(utilities, k):
 
 __all__ = [
     'approval_optimal',
+    'honest_321_ratings',
     'honest_normed_scores',
     'honest_rankings',
     'vote_for_k',

--- a/examples/bimodal_approval_strategy_comparison.py
+++ b/examples/bimodal_approval_strategy_comparison.py
@@ -1,0 +1,90 @@
+"""
+Bimodal electorate: optimal approval vs vote-for-half (and vote-for-k).
+
+Mirrors the Weber-style comparison requested in
+https://github.com/endolith/elsim/issues/20 alongside distributions_by_method.py.
+"""
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+from joblib import Parallel, delayed
+from seaborn import histplot, kdeplot
+
+from elsim.elections import bimodal_electorate, normed_dist_utilities
+from elsim.methods import approval
+from elsim.strategies import approval_optimal, vote_for_k
+
+n_elections = 50_000
+n_voters_each = 5_000
+n_cands_each = 4
+dims = 1
+disp = 0.5
+separation = 0.5
+vote_for = n_cands_each // 2
+
+batch_size = 100
+n_batches = n_elections // batch_size
+assert n_batches * batch_size == n_elections
+
+
+def human_format(num):
+    for unit in ['', 'k', 'M', 'B', 'T']:
+        if abs(num) < 1000:
+            return f"{num:.3g}{unit}"
+        num /= 1000.0
+
+
+def simulate_batch(seed):
+    rng = np.random.default_rng(seed)
+    winners = defaultdict(list)
+    for _ in range(batch_size):
+        v, c = bimodal_electorate(
+            n_voters_each, n_cands_each, dims=dims, disp=disp,
+            separation=separation, random_state=rng)
+        utilities = normed_dist_utilities(v, c)
+
+        winner = approval(approval_optimal(utilities), tiebreaker='random')
+        winners['Approval (optimal / mean threshold)'].append(c[winner][0])
+
+        winner = approval(vote_for_k(utilities, 'half'), tiebreaker='random')
+        winners[f'Approval (vote-for-{vote_for})'].append(c[winner][0])
+
+        winner = approval(vote_for_k(utilities, 1), tiebreaker='random')
+        winners['Approval (vote-for-1)'].append(c[winner][0])
+
+        winner = np.argmin(np.abs(c[:, 0]))
+        winners['Nearest cluster center'].append(c[winner][0])
+
+    return winners
+
+
+jobs = [delayed(simulate_batch)(k) for k in range(n_batches)]
+print(f'{len(jobs)} tasks total:')
+results = Parallel(n_jobs=-3, verbose=5)(jobs)
+
+winners = {k: [v for d in results for v in d[k]] for k in results[0]}
+
+title = (f'Bimodal approval strategies, {human_format(n_elections)} elections, '
+         f'{2 * n_voters_each} voters, ±{separation} separation')
+
+v, _ = bimodal_electorate(n_voters_each, 50, dims=dims, disp=disp,
+                          separation=separation)
+
+fig, ax = plt.subplots(nrows=len(winners), num=title, sharex=True,
+                       constrained_layout=True, figsize=(7.5, 8))
+fig.suptitle(title)
+for n, method in enumerate(winners.keys()):
+    histplot(winners[method], ax=ax[n], label='Winners', stat='density')
+    ax[n].set_title(method, loc='left')
+    ax[n].set_yticklabels([])
+    ax[n].set_ylabel('')
+
+    tmp = ax[n].twinx()
+    kdeplot(v[:, 0], ax=tmp, ls=':', label='Voters')
+    ax[n].plot([], [], ls=':', label='Voters')
+    tmp.set_yticklabels([])
+    tmp.set_ylabel('')
+
+ax[0].set_xlim(-2.5, 2.5)
+ax[0].legend()

--- a/examples/bimodal_winner_distributions.py
+++ b/examples/bimodal_winner_distributions.py
@@ -1,0 +1,161 @@
+"""
+Winner distributions with a bimodal electorate (two partisan clusters).
+
+Suggested in https://github.com/endolith/elsim/issues/20 — two groups of voters
+(5k + 5k) centered at ±0.5 on one ideological dimension, candidates drawn in
+two matching clusters, plus partisan primaries with optional lower primary /
+runoff turnout than the general electorate.
+
+Similar layout to distributions_by_method.py.
+"""
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+from joblib import Parallel, delayed
+from seaborn import histplot, kdeplot
+
+from elsim.elections import bimodal_electorate, normed_dist_utilities
+from elsim.methods import (approval, black, closed_partisan_primary_runoff,
+                           fptp, irv, open_partisan_primary, runoff, score, star,
+                           three_two_one, top_two_runoff_reduced_turnout)
+from elsim.strategies import (approval_optimal, honest_321_ratings,
+                              honest_normed_scores, honest_rankings,
+                              vote_for_k)
+
+n_elections = 50_000
+n_voters_each = 5_000
+n_cands_each = 4
+dims = 1
+disp = 0.5
+separation = 0.5
+
+primary_each = 3_800
+runoff_n = 8_500
+
+tb = 'random'
+
+batch_size = 100
+n_batches = n_elections // batch_size
+assert n_batches * batch_size == n_elections
+
+
+def human_format(num):
+    for unit in ['', 'k', 'M', 'B', 'T']:
+        if abs(num) < 1000:
+            return f"{num:.3g}{unit}"
+        num /= 1000.0
+
+
+def simulate_batch(seed):
+    rng = np.random.default_rng(seed)
+    winners = defaultdict(list)
+    for _ in range(batch_size):
+        v, c = bimodal_electorate(
+            n_voters_each, n_cands_each, dims=dims, disp=disp,
+            separation=separation, random_state=rng)
+
+        utilities = normed_dist_utilities(v, c)
+        rankings = honest_rankings(utilities)
+
+        left_v = np.arange(0, n_voters_each)
+        right_v = np.arange(n_voters_each, 2 * n_voters_each)
+        all_v = np.arange(2 * n_voters_each)
+
+        primary_left = rng.choice(left_v, size=primary_each, replace=False)
+        primary_right = rng.choice(right_v, size=primary_each, replace=False)
+        runoff_voters = rng.choice(all_v, size=runoff_n, replace=False)
+
+        winner = rng.integers(0, c.shape[0])
+        winners['Random winner (candidate distribution)'].append(c[winner][0])
+
+        winner = fptp(rankings, tiebreaker=tb)
+        winners['First past the post'].append(c[winner][0])
+
+        winner = runoff(rankings, tiebreaker=tb)
+        winners['Top-two runoff (contingent vote, full electorate)'].append(
+            c[winner][0])
+
+        winner = top_two_runoff_reduced_turnout(
+            rankings, all_v, runoff_voters, tiebreaker=tb)
+        if winner is None:
+            continue
+        winners['Top-two runoff (pairwise subset of voters)'].append(
+            c[winner][0])
+
+        winner = irv(rankings, tiebreaker=tb)
+        winners['Instant-runoff (Hare)'].append(c[winner][0])
+
+        ballots = honest_normed_scores(utilities, max_score=5, min_score=0)
+        winner = score(ballots, tiebreaker=tb)
+        winners['Score voting (0–5)'].append(c[winner][0])
+
+        winner = star(ballots, tiebreaker=tb)
+        winners['STAR voting (0–5)'].append(c[winner][0])
+
+        winner = black(rankings, tiebreaker=tb)
+        winners['Black (Condorcet + RCV)'].append(c[winner][0])
+
+        winner = open_partisan_primary(
+            rankings, n_cands_each, primary_left, primary_right, all_v,
+            tiebreaker=tb)
+        winners['Open partisan primary → general (subset primary electorate)'].append(
+            c[winner][0])
+
+        winner = closed_partisan_primary_runoff(
+            rankings, n_cands_each, primary_left, primary_right,
+            runoff_voters, tiebreaker=tb)
+        winners['Closed partisan primary → runoff (subset runoff electorate)'].append(
+            c[winner][0])
+
+        ballots321 = honest_321_ratings(utilities)
+        winner = three_two_one(ballots321, tiebreaker=tb)
+        if winner is None:
+            continue
+        winners['3-2-1 voting'].append(c[winner][0])
+
+        winner = approval(approval_optimal(utilities), tiebreaker=tb)
+        winners['Approval (threshold at mean utility)'].append(c[winner][0])
+
+        winner = approval(vote_for_k(utilities, 'half'), tiebreaker=tb)
+        winners[f'Approval (vote-for-{n_cands_each // 2} per party pool)'].append(
+            c[winner][0])
+
+        winner = np.argmin(np.abs(c[:, 0]))
+        winners['Nearest cluster center (ideal spatial winner)'].append(
+            c[winner][0])
+
+    return winners
+
+
+jobs = [delayed(simulate_batch)(k) for k in range(n_batches)]
+print(f'{len(jobs)} tasks total:')
+results = Parallel(n_jobs=-3, verbose=5)(jobs)
+
+winners = {k: [v for d in results for v in d[k]] for k in results[0]}
+
+title = (f'{human_format(n_elections)} 1D elections, '
+         f'{human_format(2 * n_voters_each)} bimodal voters '
+         f'({human_format(n_voters_each)} per mode ±{separation}), '
+         f'{n_cands_each} candidates per cluster, {disp} dispersion')
+
+v, _ = bimodal_electorate(n_voters_each, 50, dims=dims, disp=disp,
+                          separation=separation)
+
+fig, ax = plt.subplots(nrows=len(winners), num=title, sharex=True,
+                       constrained_layout=True, figsize=(7.5, 14))
+fig.suptitle(title)
+for n, method in enumerate(winners.keys()):
+    histplot(winners[method], ax=ax[n], label='Winners', stat='density')
+    ax[n].set_title(method, loc='left')
+    ax[n].set_yticklabels([])
+    ax[n].set_ylabel('')
+
+    tmp = ax[n].twinx()
+    kdeplot(v[:, 0], ax=tmp, ls=':', label='Voters')
+    ax[n].plot([], [], ls=':', label='Voters')
+    tmp.set_yticklabels([])
+    tmp.set_ylabel('')
+
+ax[0].set_xlim(-2.5, 2.5)
+ax[0].legend()

--- a/examples/score_star_range_comparison.py
+++ b/examples/score_star_range_comparison.py
@@ -1,0 +1,94 @@
+"""
+Compare Score and STAR winner distributions across ballot ranges.
+
+Uses the same normalized spatial utilities as other 1D examples; only the
+quantized score range changes. Ranges follow the discussion in
+https://github.com/endolith/elsim/issues/20 (0–5 advocacy scale, 0–10 vs 1–10,
+course-style 5 / 13 / 15 levels).
+
+Similar layout to distributions_by_method.py (stacked histograms).
+"""
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+from joblib import Parallel, delayed
+from seaborn import histplot, kdeplot
+
+from elsim.elections import normal_electorate, normed_dist_utilities
+from elsim.methods import score, star
+from elsim.strategies import honest_normed_scores
+
+n_elections = 50_000
+n_voters = 1_000
+n_cands = 7
+dims = 1
+disp = 0.5
+
+ballot_specs = [
+    ('0–5', 0, 5),
+    ('0–10', 0, 10),
+    ('1–10', 1, 10),
+    ('Five grades (0–4)', 0, 4),
+    ('13 levels (0–12)', 0, 12),
+    ('15 levels (0–14)', 0, 14),
+]
+
+batch_size = 100
+n_batches = n_elections // batch_size
+assert n_batches * batch_size == n_elections
+
+
+def human_format(num):
+    for unit in ['', 'k', 'M', 'B', 'T']:
+        if abs(num) < 1000:
+            return f"{num:.3g}{unit}"
+        num /= 1000.0
+
+
+def simulate_batch(seed):
+    rng = np.random.default_rng(seed)
+    out = defaultdict(list)
+    for _ in range(batch_size):
+        v, c = normal_electorate(n_voters, n_cands, dims=dims, disp=disp,
+                                 random_state=rng)
+        utilities = normed_dist_utilities(v, c)
+        for label, mn, mx in ballot_specs:
+            ballots = honest_normed_scores(
+                utilities, max_score=mx, min_score=mn)
+            w_s = score(ballots, tiebreaker='random')
+            w_t = star(ballots, tiebreaker='random')
+            out[f'Score {label}'].append(c[w_s][0])
+            out[f'STAR {label}'].append(c[w_t][0])
+    return out
+
+
+jobs = [delayed(simulate_batch)(k) for k in range(n_batches)]
+print(f'{len(jobs)} tasks total:')
+results = Parallel(n_jobs=-3, verbose=5)(jobs)
+
+winners = {k: [v for d in results for v in d[k]] for k in results[0]}
+
+title = (f'Score vs STAR by ballot range, {human_format(n_elections)} '
+         f'1D elections, {human_format(n_voters)} voters, '
+         f'{human_format(n_cands)} candidates, {disp} dispersion')
+
+v, _ = normal_electorate(n_voters, 1000, dims=dims)
+
+fig, ax = plt.subplots(nrows=len(winners), num=title, sharex=True,
+                       constrained_layout=True, figsize=(7.5, 16))
+fig.suptitle(title)
+for n, method in enumerate(winners.keys()):
+    histplot(winners[method], ax=ax[n], label='Winners', stat='density')
+    ax[n].set_title(method, loc='left')
+    ax[n].set_yticklabels([])
+    ax[n].set_ylabel('')
+
+    tmp = ax[n].twinx()
+    kdeplot(v[:, 0], ax=tmp, ls=':', label='Voters')
+    ax[n].plot([], [], ls=':', label='Voters')
+    tmp.set_yticklabels([])
+    tmp.set_ylabel('')
+
+ax[0].set_xlim(-2.5, 2.5)
+ax[0].legend()

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -3,8 +3,9 @@ import pytest
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
 
-from elsim.elections import (impartial_culture, normal_electorate,
-                             normed_dist_utilities, random_utilities)
+from elsim.elections import (bimodal_electorate, impartial_culture,
+                             normal_electorate, normed_dist_utilities,
+                             random_utilities)
 
 
 def test_random_utilities():
@@ -125,8 +126,18 @@ def test_random_state(func):
     assert_array_equal(c, f)
 
 
+def test_bimodal_electorate():
+    rng = np.random.default_rng(42)
+    v, c = bimodal_electorate(500, 4, dims=1, disp=0.5, separation=0.5,
+                              random_state=rng)
+    assert v.shape == (1000, 1)
+    assert c.shape == (8, 1)
+    assert np.mean(v[:500]) < np.mean(v[500:])
+    assert np.mean(c[:4]) < np.mean(c[4:])
+
+
 @pytest.mark.parametrize("func", [random_utilities, impartial_culture,
-                                  normal_electorate])
+                                  normal_electorate, bimodal_electorate])
 def test_invalid_random_state(func):
     with pytest.raises(ValueError):
         func(5, 5, random_state='bananas')

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,12 +1,14 @@
 import pytest
 
 from elsim.methods import (approval, black, borda, combined_approval, coombs,
-                           fptp, irv, runoff, score, utility_winner)
+                           fptp, irv, runoff, score, star, three_two_one,
+                           utility_winner)
 
 
 @pytest.mark.parametrize("method", [black, borda, fptp, runoff, irv, coombs,
                                     approval, combined_approval,
-                                    utility_winner, score])
+                                    utility_winner, score, star,
+                                    three_two_one])
 def test_invalid_tiebreaker(method):
     with pytest.raises(ValueError):
         election = [[0, 1],

--- a/tests/test_partisan_primaries.py
+++ b/tests/test_partisan_primaries.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+
+from elsim.methods.partisan_primaries import (
+    closed_partisan_primary_runoff,
+    nominee_restricted_plurality,
+    open_partisan_primary,
+    pairwise_majority_from_rankings,
+    top_two_runoff_reduced_turnout,
+)
+
+
+def test_nominee_restricted_plurality_basic():
+    rankings = np.array([
+        [0, 1, 2, 3],
+        [0, 2, 1, 3],
+        [2, 3, 0, 1],
+        [2, 0, 1, 3],
+    ], dtype=np.uint8)
+    assert nominee_restricted_plurality(
+        rankings, [0, 1], np.array([0, 1]), 'order') == 0
+    assert nominee_restricted_plurality(
+        rankings, [2, 3], np.array([2, 3]), 'order') == 2
+
+
+def test_nominee_restricted_plurality_tie_order():
+    rankings = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    assert nominee_restricted_plurality(
+        rankings, [0, 1], np.array([0, 1]), 'order') == 0
+
+
+def test_pairwise_majority_prefers_a():
+    rankings = np.array([
+        [0, 1],
+        [0, 1],
+        [1, 0],
+    ], dtype=np.uint8)
+    assert pairwise_majority_from_rankings(
+        rankings, [0, 1, 2], 0, 1, 'order') == 0
+
+
+def test_pairwise_majority_prefers_b():
+    rankings = np.array([
+        [1, 0],
+        [1, 0],
+        [0, 1],
+    ], dtype=np.uint8)
+    assert pairwise_majority_from_rankings(
+        rankings, [0, 1, 2], 0, 1, 'order') == 1
+
+
+def test_pairwise_majority_tie_order():
+    rankings = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    assert pairwise_majority_from_rankings(
+        rankings, [0, 1], 0, 1, 'order') == 0
+
+
+def test_open_partisan_primary():
+    rankings = np.array([
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [2, 3, 0, 1],
+        [2, 3, 0, 1],
+    ], dtype=np.uint8)
+    w = open_partisan_primary(
+        rankings, 2, [0, 1], [2, 3], [0, 1, 2, 3], 'order')
+    assert w == 0
+
+
+def test_closed_partisan_primary_runoff_subset():
+    rankings = np.array([
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [2, 3, 0, 1],
+        [2, 3, 0, 1],
+    ], dtype=np.uint8)
+    w = closed_partisan_primary_runoff(
+        rankings, 2, [0, 1], [2, 3], [0, 2], 'order')
+    assert w == 0
+
+
+def test_top_two_runoff_unanimous_first_place():
+    rankings = np.array([[0, 1, 2], [0, 2, 1], [0, 1, 2]], dtype=np.uint8)
+    w = top_two_runoff_reduced_turnout(
+        rankings, [0, 1, 2], [0, 1, 2], 'order')
+    assert w == 0
+
+
+def test_top_two_runoff_two_finalists_pairwise():
+    rankings = np.array([
+        [0, 1, 2],
+        [0, 2, 1],
+        [1, 0, 2],
+        [1, 2, 0],
+    ], dtype=np.uint8)
+    w = top_two_runoff_reduced_turnout(
+        rankings, np.arange(4), np.arange(4), 'order')
+    assert w == 0
+
+
+def test_top_two_runoff_sntv_returns_none():
+    rankings = np.array([
+        [0, 1, 2, 3],
+        [1, 0, 2, 3],
+        [2, 1, 0, 3],
+        [3, 1, 2, 0],
+    ], dtype=np.uint8)
+    assert top_two_runoff_reduced_turnout(
+        rankings, [0, 1, 2, 3], [0, 1, 2, 3], tiebreaker=None) is None
+
+
+def test_top_two_runoff_too_many_sntv_winners_returns_none():
+    from unittest.mock import patch
+
+    rankings = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    with patch('elsim.methods.partisan_primaries.sntv',
+               return_value={0, 1, 2}):
+        assert top_two_runoff_reduced_turnout(
+            rankings, [0, 1], [0, 1], 'order') is None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -5,7 +5,8 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats, integers, tuples
 from numpy.testing import assert_array_equal
 
-from elsim.strategies import approval_optimal, honest_normed_scores, vote_for_k
+from elsim.strategies import (approval_optimal, honest_321_ratings,
+                              honest_normed_scores, vote_for_k)
 
 
 def test_approval_optimal():
@@ -36,6 +37,28 @@ def test_honest_normed_scores():
                                                             [0, 7, 5],
                                                             [0, 2, 7],
                                                             ])
+
+
+def test_honest_normed_scores_invalid_range():
+    with pytest.raises(ValueError):
+        honest_normed_scores([[0.0, 1.0]], max_score=1, min_score=5)
+
+
+def test_honest_321_ratings_shapes():
+    assert_array_equal(honest_321_ratings([[1.0]]), [[2]])
+    assert_array_equal(
+        honest_321_ratings([[0.0, 1.0], [1.0, 0.0]]),
+        [[0, 2], [2, 0]])
+    u = np.ones((1, 9))
+    r = honest_321_ratings(u)
+    assert r.shape == (1, 9)
+    assert set(np.unique(r)) <= {0, 1, 2}
+
+
+def test_honest_321_ratings_too_many_candidates():
+    utilities = np.ones((1, 256))
+    with pytest.raises(ValueError):
+        honest_321_ratings(utilities)
 
 
 def test_vote_for_k():

--- a/tests/test_three_two_one.py
+++ b/tests/test_three_two_one.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from elsim.methods import three_two_one
+
+
+def test_three_two_one_invalid_ballots():
+    with pytest.raises(ValueError):
+        three_two_one([[3, 0]])
+
+
+def test_three_two_one_invalid_tiebreaker():
+    with pytest.raises(ValueError):
+        three_two_one([[2, 1, 0]], tiebreaker='nope')
+
+
+def test_three_two_one_single_candidate():
+    election = np.array([[2], [1], [0]], dtype=np.uint8)
+    assert three_two_one(election, 'order') == 0
+
+
+def test_three_two_one_two_candidates():
+    election = np.array([[2, 0], [2, 0], [0, 2]], dtype=np.uint8)
+    assert three_two_one(election, 'order') == 0
+
+
+def test_three_two_one_eliminates_most_bad():
+    # Semifinalists 0,1,2 by Good count; among them candidate 1 has most Bad.
+    election = np.array([
+        [2, 1, 0],
+        [2, 1, 0],
+        [2, 0, 1],
+        [2, 0, 1],
+        [0, 2, 1],
+    ], dtype=np.uint8)
+    assert three_two_one(election, 'order') == 0

--- a/tests/test_three_two_one.py
+++ b/tests/test_three_two_one.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from elsim.methods import three_two_one
+from elsim.methods.three_two_one import _pairwise_rating_preference
 
 
 def test_three_two_one_invalid_ballots():
@@ -22,6 +23,31 @@ def test_three_two_one_single_candidate():
 def test_three_two_one_two_candidates():
     election = np.array([[2, 0], [2, 0], [0, 2]], dtype=np.uint8)
     assert three_two_one(election, 'order') == 0
+
+
+def test_three_two_one_two_candidates_second_wins():
+    election = np.array([[0, 2], [0, 2], [2, 0]], dtype=np.uint8)
+    assert three_two_one(election, 'order') == 1
+
+
+def test_three_two_one_requires_2d():
+    with pytest.raises(ValueError, match='2D'):
+        three_two_one(np.array([0, 1, 2]))
+
+
+def test_pairwise_rating_preference_total_score_favors_a():
+    election = np.array([[0, 1], [2, 0]], dtype=np.uint8)
+    assert _pairwise_rating_preference(election, 0, 1, 'order') == 0
+
+
+def test_pairwise_rating_preference_total_score_favors_b():
+    election = np.array([[0, 2], [1, 0]], dtype=np.uint8)
+    assert _pairwise_rating_preference(election, 0, 1, 'order') == 1
+
+
+def test_pairwise_rating_preference_full_tie_none_tiebreaker():
+    election = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    assert _pairwise_rating_preference(election, 0, 1, None) is None
 
 
 def test_three_two_one_eliminates_most_bad():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR implements the simulations and mechanisms discussed in [issue #20](https://github.com/endolith/elsim/issues/20).

### Library additions
- **`bimodal_electorate`** (`elsim.elections`): two voter clusters and matching candidate pools at ±`separation` on the first axis (documented indexing convention for left/right voters and candidates).
- **`three_two_one`** (`elsim.methods`): 3-2-1 voting with ballots encoded as 0 = Bad, 1 = OK, 2 = Good (party-specific semifinalist rules omitted as optional for simulations).
- **`honest_321_ratings`** (`elsim.strategies`): per-voter tertiles → Good/OK/Bad.
- **`honest_normed_scores(utilities, max_score=5, *, min_score=0)`**: keyword-only `min_score`; keeps positional `max_score` for backward compatibility; rows with no utility spread map to `min_score`.
- **Partisan helpers** (`elsim.methods`): restricted plurality nominees, pairwise majority between finalists, open vs closed partisan flows, top-two runoff with a subset electorate in the pairwise round.

### Examples (same style as `distributions_by_method.py`)
- **`examples/bimodal_winner_distributions.py`**: 5k+5k voters, two clusters of candidates, dispersion 0.5, reduced-turnout primaries (~3.8k each side) and runoff (~8.5k voters). Methods include FPTP, contingent runoff, IRV, Score/STAR (0–5), Black, open/closed partisan primaries, 3-2-1, approval (mean threshold and vote-for-half), reference histograms.
- **`examples/score_star_range_comparison.py`**: same unimodal spatial setup as existing 1D plots; compares Score vs STAR for ranges 0–5, 0–10, 1–10, five-grade (0–4), 13- and 15-point scales.
- **`examples/bimodal_approval_strategy_comparison.py`**: optimal approval vs vote-for-half vs vote-for-one on the bimodal electorate.

### Tests
- `bimodal_electorate` shape/means; `three_two_one` edge cases; extended invalid tiebreaker coverage.

All tests pass (`pytest tests/`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49490462-beeb-4302-8144-24defe3e4616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49490462-beeb-4302-8144-24defe3e4616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

