### PR TITLE
Add 95% error bars to simulation examples (exact binomial + bootstrap SUE)

### DIFF
--- a/examples/merrill_1984_fig_2c_2d.py
+++ b/examples/merrill_1984_fig_2c_2d.py
@@ -53,6 +53,8 @@ from elsim.methods import (approval, black, borda, condorcet, coombs, fptp,
                            irv, runoff, utility_winner)
 from elsim.strategies import approval_optimal, honest_rankings
 
+from plot_uncertainty import binomial_proportion_ci_errors_percent
+
 n_elections = 10_000  # Roughly 30 seconds each on a 2019 6-core i7-9750H
 n_voters = 201
 n_cands_list = (2, 3, 4, 5, 6, 7)
@@ -138,17 +140,30 @@ for fig, disp, ymin, orig in (('2.c', 1.0, 50, merrill_fig_2c),
 
     # Of those elections with CW, likelihood that method chooses CW
     x_cw, y_cw = zip(*sorted(condorcet_winner_count['CW'].items()))
+    y_cw_a = np.asarray(y_cw)
     for method in ('Black', 'Coombs', 'Borda', 'Approval', 'Hare', 'Runoff',
                    'Plurality'):
         x, y = zip(*sorted(condorcet_winner_count[method].items()))
-        CE = np.array(y)/y_cw
-        plt.plot(x, CE*100, '-', label=method)
-        table.append([method, *CE*100])
+        k = np.asarray(y)
+        CE = k / y_cw_a
+        el, eh = binomial_proportion_ci_errors_percent(k, y_cw_a)
+        plt.errorbar(x, CE * 100, yerr=[el, eh], fmt='-', label=method,
+                     capsize=2, elinewidth=0.8)
+        table.append([method, *CE * 100])
 
     print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
     print()
 
     plt.plot([], [], 'k:', lw=0.8, label='Merrill')  # Dummy plot for label
+    plt.figtext(
+        0.99,
+        0.01,
+        'Simulation error bars: 95% exact (Clopper–Pearson) CI for binomial '
+        'proportion',
+        fontsize=7,
+        ha='right',
+        va='bottom',
+    )
     plt.legend()
     plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
     plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/merrill_1984_fig_2c_2d_updated.py
+++ b/examples/merrill_1984_fig_2c_2d_updated.py
@@ -58,6 +58,8 @@ from elsim.methods import (approval, black, borda, condorcet, coombs, fptp,
 from elsim.strategies import (approval_optimal, honest_normed_scores,
                               honest_rankings)
 
+from plot_uncertainty import binomial_proportion_ci_errors_percent
+
 n_elections = 5_000  # Roughly 30 seconds each on a 2019 6-core i7-9750H
 n_voters = 201
 n_cands_list = (2, 3, 4, 5, 6, 7)
@@ -117,17 +119,30 @@ for fig, disp, ymin in (('2.c', 1.0, 50),
 
     # Of those elections with CW, likelihood that method chooses CW
     x_cw, y_cw = zip(*sorted(condorcet_winner_count['CW'].items()))
+    y_cw_a = np.asarray(y_cw)
     for method in ('Condorcet RCV', 'Coombs', 'STAR', 'Borda', 'Score',
                    'Approval (opt.)', 'Hare RCV', 'Top-2 Runoff', 'Plurality'):
         x, y = zip(*sorted(condorcet_winner_count[method].items()))
-        CE = np.array(y)/y_cw
-        plt.plot(x, CE*100, '-', label=method)
-        table.append([method, *CE*100])
+        k = np.asarray(y)
+        CE = k / y_cw_a
+        el, eh = binomial_proportion_ci_errors_percent(k, y_cw_a)
+        plt.errorbar(x, CE * 100, yerr=[el, eh], fmt='-', label=method,
+                     capsize=2, elinewidth=0.8)
+        table.append([method, *CE * 100])
 
     print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
     print()
 
     plt.legend()
+    plt.figtext(
+        0.99,
+        0.01,
+        'Simulation error bars: 95% exact (Clopper–Pearson) CI for binomial '
+        'proportion',
+        fontsize=7,
+        ha='right',
+        va='bottom',
+    )
     plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
     plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')
     plt.ylim(ymin, 102)

--- a/examples/merrill_1984_fig_4a_4b.py
+++ b/examples/merrill_1984_fig_4a_4b.py
@@ -41,7 +41,6 @@ discrepancies.  It is smoother, so maybe the original just had lower number of
 simulations.
 """
 import time
-from collections import Counter
 from random import randint
 
 import matplotlib.pyplot as plt
@@ -52,6 +51,8 @@ from elsim.elections import normal_electorate, normed_dist_utilities
 from elsim.methods import (approval, black, borda, coombs, fptp, irv, runoff,
                            utility_winner)
 from elsim.strategies import approval_optimal, honest_rankings
+
+from plot_uncertainty import sue_ratio_curve_points_and_errors
 
 n_elections = 10_000  # Roughly 30 seconds each on a 2019 6-core i7-9750H
 n_voters = 201
@@ -90,29 +91,37 @@ merrill_fig_4b = {
 for fig, disp, ymin, orig in (('4.a', 1.0, 55, merrill_fig_4a),
                               ('4.b', 0.5, 0, merrill_fig_4b)):
 
-    utility_sums = {key: Counter() for key in (ranked_methods.keys() |
-                                               rated_methods.keys() |
-                                               {'SU max', 'RW'})}
+    idx = {nc: i for i, nc in enumerate(n_cands_list)}
+    nc_ct = len(n_cands_list)
+    plot_keys = list(ranked_methods.keys()) + list(rated_methods.keys())
+    A_elec = {m: np.zeros((nc_ct, n_elections)) for m in plot_keys}
+    B_z = np.zeros((nc_ct, n_elections))
     start_time = time.monotonic()
 
     for iteration in range(n_elections):
         for n_cands in n_cands_list:
+            j = idx[n_cands]
             v, c = normal_electorate(n_voters, n_cands, dims=D, corr=corr,
                                      disp=disp)
             utilities = normed_dist_utilities(v, c)
             rankings = honest_rankings(utilities)
 
-            # Pick a random winner and accumulate utilities
             RW = randint(0, n_cands - 1)
-            utility_sums['RW'][n_cands] += utilities.sum(axis=0)[RW]
+            rw_sum = utilities.sum(axis=0)[RW]
+
+            uw = utility_winner(utilities)
+            su_sum = utilities.sum(axis=0)[uw]
+            B_z[j, iteration] = su_sum - rw_sum
 
             for name, method in rated_methods.items():
                 winner = method(utilities, tiebreaker='random')
-                utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+                A_elec[name][j, iteration] = (
+                    utilities.sum(axis=0)[winner] - rw_sum)
 
             for name, method in ranked_methods.items():
                 winner = method(rankings, tiebreaker='random')
-                utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+                A_elec[name][j, iteration] = (
+                    utilities.sum(axis=0)[winner] - rw_sum)
 
     elapsed_time = time.monotonic() - start_time
     print('Elapsed:', time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),
@@ -135,20 +144,33 @@ for fig, disp, ymin, orig in (('4.a', 1.0, 55, merrill_fig_4a),
 
     table = []
 
-    # Calculate Social Utility Efficiency from summed utilities
-    x_uw, y_uw = zip(*sorted(utility_sums['SU max'].items()))
-    x_rw, y_rw = zip(*sorted(utility_sums['RW'].items()))
+    rng = np.random.default_rng(0)
+    xp = list(n_cands_list)
+
+    # SUE = sum(method total - RW total) / sum(SU max total - RW total)
     for method in ('Black', 'Coombs', 'Borda', 'Approval', 'Hare', 'Runoff',
                    'Plurality'):
-        x, y = zip(*sorted(utility_sums[method].items()))
-        SUE = (np.array(y) - y_rw) / (np.array(y_uw) - y_rw)
-        plt.plot(x, SUE*100, '-', label=method)
-        table.append([method, *SUE*100])
+        y, el, eh = sue_ratio_curve_points_and_errors(
+            A_elec[method], B_z, rng=rng)
+        plt.errorbar(xp, y, yerr=[el, eh], fmt='-', label=method,
+                     capsize=2, elinewidth=0.8)
+        table.append([method, *y])
 
-    print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
+    print(tabulate(table, ["Method", *xp], tablefmt="pipe", floatfmt='.1f'))
     print()
 
     plt.plot([], [], 'k:', lw=0.8, label='Merrill')  # Dummy plot for label
+    plt.figtext(
+        0.99,
+        0.01,
+        'Simulation error bars: 95% percentile bootstrap CI for '
+        'sum(A_i)/sum(B_i) with paired election resampling '
+        '(A_i = method utility sum minus random winner sum; '
+        'B_i = SU-max sum minus random winner sum).',
+        fontsize=7,
+        ha='right',
+        va='bottom',
+    )
     plt.legend()
     plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
     plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/merrill_1984_fig_4a_4b_updated.py
+++ b/examples/merrill_1984_fig_4a_4b_updated.py
@@ -45,7 +45,6 @@ discrepancies.  It is smoother, so maybe the original just had lower number of
 simulations.
 """
 import time
-from collections import Counter
 from random import randint
 
 import matplotlib.pyplot as plt
@@ -57,6 +56,8 @@ from elsim.methods import (approval, black, borda, coombs, fptp, irv, runoff,
                            score, star, utility_winner)
 from elsim.strategies import (approval_optimal, honest_normed_scores,
                               honest_rankings)
+
+from plot_uncertainty import sue_ratio_curve_points_and_errors
 
 n_elections = 5_000  # Roughly 30 seconds each on a 2019 6-core i7-9750H
 n_voters = 201
@@ -81,29 +82,37 @@ rated_methods = {'SU max': utility_winner,
 for fig, disp, ymin in (('4.a', 1.0, 55),
                         ('4.b', 0.5, 0)):
 
-    utility_sums = {key: Counter() for key in (ranked_methods.keys() |
-                                               rated_methods.keys() |
-                                               {'SU max', 'RW'})}
+    idx = {nc: i for i, nc in enumerate(n_cands_list)}
+    nc_ct = len(n_cands_list)
+    plot_keys = list(ranked_methods.keys()) + list(rated_methods.keys())
+    A_elec = {m: np.zeros((nc_ct, n_elections)) for m in plot_keys}
+    B_z = np.zeros((nc_ct, n_elections))
     start_time = time.monotonic()
 
     for iteration in range(n_elections):
         for n_cands in n_cands_list:
+            j = idx[n_cands]
             v, c = normal_electorate(n_voters, n_cands, dims=D, corr=corr,
                                      disp=disp)
             utilities = normed_dist_utilities(v, c)
             rankings = honest_rankings(utilities)
 
-            # Pick a random winner and accumulate utilities
             RW = randint(0, n_cands - 1)
-            utility_sums['RW'][n_cands] += utilities.sum(axis=0)[RW]
+            rw_sum = utilities.sum(axis=0)[RW]
+
+            uw = utility_winner(utilities)
+            su_sum = utilities.sum(axis=0)[uw]
+            B_z[j, iteration] = su_sum - rw_sum
 
             for name, method in rated_methods.items():
                 winner = method(utilities, tiebreaker='random')
-                utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+                A_elec[name][j, iteration] = (
+                    utilities.sum(axis=0)[winner] - rw_sum)
 
             for name, method in ranked_methods.items():
                 winner = method(rankings, tiebreaker='random')
-                utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+                A_elec[name][j, iteration] = (
+                    utilities.sum(axis=0)[winner] - rw_sum)
 
     elapsed_time = time.monotonic() - start_time
     print('Elapsed:', time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),
@@ -116,22 +125,32 @@ for fig, disp, ymin in (('4.a', 1.0, 55),
 
     table = []
 
-    # Calculate Social Utility Efficiency from summed utilities
-    x_uw, y_uw = zip(*sorted(utility_sums['SU max'].items()))
-    x_rw, y_rw = zip(*sorted(utility_sums['RW'].items()))
+    rng = np.random.default_rng(0)
+    xp = list(n_cands_list)
+
     for method in ('Score', 'STAR', 'Borda', 'Condorcet RCV', 'Coombs',
                    'Approval (opt.)', 'Hare RCV', 'Top-2 Runoff', 'Plurality'):
-        x, y = zip(*sorted(utility_sums[method].items()))
-        SUE = (np.array(y) - y_rw) / (np.array(y_uw) - y_rw)
-        plt.plot(x, SUE*100, '-', label=method)
-        table.append([method, *SUE*100])
+        y, el, eh = sue_ratio_curve_points_and_errors(
+            A_elec[method], B_z, rng=rng)
+        plt.errorbar(xp, y, yerr=[el, eh], fmt='-', label=method,
+                     capsize=2, elinewidth=0.8)
+        table.append([method, *y])
 
-    print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
+    print(tabulate(table, ["Method", *xp], tablefmt="pipe", floatfmt='.1f'))
     print()
 
     plt.legend()
+    plt.figtext(
+        0.99,
+        0.01,
+        'Simulation error bars: 95% percentile bootstrap CI for '
+        'sum(A_i)/sum(B_i) with paired election resampling.',
+        fontsize=7,
+        ha='right',
+        va='bottom',
+    )
     plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
     plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')
-    plt.ylim(85, 100.5)  # or ymin
+    plt.ylim(ymin, 100.5)
     plt.xlim(1.8, 7.2)
     plt.show()

--- a/examples/merrill_1984_table_1_fig_1.py
+++ b/examples/merrill_1984_table_1_fig_1.py
@@ -36,6 +36,8 @@ from elsim.methods import (approval, black, borda, condorcet, coombs, fptp,
                            irv, runoff, utility_winner)
 from elsim.strategies import approval_optimal, honest_rankings
 
+from plot_uncertainty import binomial_proportion_ci_errors_percent
+
 n_elections = 10_000  # Roughly 15 seconds on a 2019 6-core i7-9750H
 n_voters = 25
 n_cands_list = (2, 3, 4, 5, 7, 10)
@@ -111,12 +113,16 @@ table = []
 
 # Of those elections with CW, likelihood that method chooses CW
 x_cw, y_cw = zip(*sorted(condorcet_winner_count['CW'].items()))
+y_cw_a = np.asarray(y_cw)
 for method in ('Plurality', 'Runoff', 'Hare', 'Approval', 'Borda', 'Coombs',
                'Black'):
     x, y = zip(*sorted(condorcet_winner_count[method].items()))
-    CE = np.array(y)/y_cw
-    plt.plot(x, CE*100, '-', label=method)
-    table.append([method, *np.array(y)/y_cw*100])
+    k = np.asarray(y)
+    CE = k / y_cw_a
+    el, eh = binomial_proportion_ci_errors_percent(k, y_cw_a)
+    plt.errorbar(x, CE * 100, yerr=[el, eh], fmt='-', label=method,
+                 capsize=2, elinewidth=0.8)
+    table.append([method, *CE * 100])
 
 # Likelihood that social utility maximizer is Condorcet Winner
 x, y = zip(*sorted(condorcet_winner_count['SU max'].items()))
@@ -128,6 +134,16 @@ table.append(['CW', *np.asarray(y_cw) / n_elections * 100])
 print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
 
 plt.plot([], [], 'k:', lw=0.8, label='Merrill')  # Dummy plot for label
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% exact (Clopper–Pearson) CI for binomial '
+    'proportion\n(successes = elections method picks CW; trials = elections '
+    'with a CW)',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/merrill_1984_table_3_fig_3.py
+++ b/examples/merrill_1984_table_3_fig_3.py
@@ -23,7 +23,6 @@ Typical result:
 | Black     | 100.0 | 92.9 | 92.0 | 92.1 | 93.2 | 94.6 |
 """
 import time
-from collections import Counter
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +32,8 @@ from elsim.elections import random_utilities
 from elsim.methods import (approval, black, borda, coombs, fptp, irv, runoff,
                            utility_winner)
 from elsim.strategies import approval_optimal, honest_rankings
+
+from plot_uncertainty import sue_ratio_curve_points_and_errors
 
 n_elections = 10_000  # Roughly 30 seconds on a 2019 6-core i7-9750H
 n_voters = 25
@@ -44,13 +45,17 @@ ranked_methods = {'Plurality': fptp, 'Runoff': runoff, 'Hare': irv,
 rated_methods = {'Approval': lambda utilities, tiebreaker:
                  approval(approval_optimal(utilities), tiebreaker)}
 
-utility_sums = {key: Counter() for key in (ranked_methods.keys() |
-                                           rated_methods.keys() | {'UW'})}
+idx = {nc: i for i, nc in enumerate(n_cands_list)}
+nc_ct = len(n_cands_list)
+method_keys = list(ranked_methods.keys()) + list(rated_methods.keys())
+W_elec = {m: np.zeros((nc_ct, n_elections)) for m in method_keys}
+Z_uw = np.zeros((nc_ct, n_elections))
 
 start_time = time.monotonic()
 
 for iteration in range(n_elections):
     for n_cands in n_cands_list:
+        j = idx[n_cands]
         utilities = random_utilities(n_voters, n_cands)
 
         """
@@ -62,19 +67,19 @@ for iteration in range(n_elections):
         utilities -= utilities.min(1)[:, np.newaxis]
         utilities /= utilities.max(1)[:, np.newaxis]
 
-        # Find the social utility winner and accumulate utilities
         UW = utility_winner(utilities)
-        utility_sums['UW'][n_cands] += utilities.sum(axis=0)[UW]
+        Z_uw[j, iteration] = utilities.sum(axis=0)[UW] - n_voters / 2
 
         for name, method in rated_methods.items():
             winner = method(utilities, tiebreaker='random')
-            utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+            W_elec[name][j, iteration] = (
+                utilities.sum(axis=0)[winner] - n_voters / 2)
 
         rankings = honest_rankings(utilities)
         for name, method in ranked_methods.items():
             winner = method(rankings, tiebreaker='random')
-            utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
-
+            W_elec[name][j, iteration] = (
+                utilities.sum(axis=0)[winner] - n_voters / 2)
 
 elapsed_time = time.monotonic() - start_time
 print('Elapsed:', time.strftime("%H:%M:%S", time.gmtime(elapsed_time)), '\n')
@@ -102,19 +107,33 @@ plt.gca().set_prop_cycle(None)
 
 table = []
 
-# Calculate Social Utility Efficiency from summed utilities
-x_uw, y_uw = zip(*sorted(utility_sums['UW'].items()))
+rng = np.random.default_rng(0)
+
+# Calculate Social Utility Efficiency from paired per-election totals
+x = list(n_cands_list)
 for method in ('Plurality', 'Runoff', 'Hare', 'Approval', 'Borda', 'Coombs',
                'Black'):
-    x, y = zip(*sorted(utility_sums[method].items()))
-    SUE = ((np.array(y) - n_voters * n_elections / 2) /
-           (np.array(y_uw) - n_voters * n_elections / 2))
-    plt.plot(x, SUE*100, '-', label=method)
-    table.append([method, *(SUE*100)])
+    y, el, eh = sue_ratio_curve_points_and_errors(
+        W_elec[method], Z_uw, rng=rng)
+    plt.errorbar(x, y, yerr=[el, eh], fmt='-', label=method,
+                 capsize=2, elinewidth=0.8)
+    table.append([method, *y])
 
 print(tabulate(table, ["Method", *x], tablefmt="pipe", floatfmt='.1f'))
 
 plt.plot([], [], 'k:', lw=0.8, label='Merrill')  # Dummy plot for label
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% percentile bootstrap CI for '
+    r'$\hat\theta=\sum W_i/\sum Z_i$'
+    ' (paired resimulation indices; '
+    r'$W_i$ = method utility sum $-$ random baseline; '
+    r'$Z_i$ = SU-winner utility sum $-$ baseline)',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/niemi_1968_table_1.py
+++ b/examples/niemi_1968_table_1.py
@@ -45,6 +45,8 @@ from tabulate import tabulate
 from elsim.elections import impartial_culture
 from elsim.methods import condorcet
 
+from plot_uncertainty import binomial_proportion_ci_errors_percent
+
 # Probability That There Is No Majority Winner
 niemi_table = [.0000, .0000, .0877, .1755, .2513, .3152, .3692, .4151, .4545,
                .4887, .5187, .5452, .5687, .5898, .6087, .6259, .6416, .6559,
@@ -90,9 +92,21 @@ x, y = zip(*niemi_table.items())
 plt.plot(x, y, label='Niemi')
 
 x, y = zip(*sorted(condorcet_paradox_counts.items()))
-y = np.asarray(y) / n_elections  # Percent likelihood of paradox
-plt.plot(x, y, '.', label='Simulation')
+k = np.asarray(y)
+y_pct = k / n_elections * 100  # Percent likelihood of paradox
+el, eh = binomial_proportion_ci_errors_percent(k, n_elections)
+plt.errorbar(x, y_pct, yerr=[el, eh], fmt='.', label='Simulation',
+             capsize=2, elinewidth=0.8, markersize=6)
 
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% exact (Clopper–Pearson) CI '
+    f'(binomial; {n_elections:,} elections per point)',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/plot_uncertainty.py
+++ b/examples/plot_uncertainty.py
@@ -1,0 +1,131 @@
+"""
+Uncertainty displays for Monte Carlo election simulations.
+
+Binomial counts use two-sided exact (Clopper–Pearson) intervals via
+`scipy.stats.binomtest`, i.e. inversion of the binomial test — a standard
+frequentist CI for a binomial proportion.
+
+Social utility efficiency is computed as a ratio of correlated per-election
+totals: \\hat\\theta = \\sum_i W_i / \\sum_i Z_i with paired (W_i, Z_i).
+Uncertainty for that ratio uses a paired bootstrap percentile interval on the
+same statistic (resampling simulation indices), which targets the sampling
+distribution of the plug-in estimator actually plotted.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import binomtest
+
+CONFIDENCE_LEVEL = 0.95
+
+
+def binomial_proportion_ci_errors_percent(
+    k: np.ndarray | list | int,
+    n: np.ndarray | list | int,
+) -> tuple[np.ndarray, np.ndarray] | tuple[float, float]:
+    """
+    Vertical errors for matplotlib errorbar when y is the sample proportion * 100.
+
+    Parameters
+    ----------
+    k : number of successes
+    n : number of trials
+    """
+    k_arr = np.atleast_1d(np.asarray(k, dtype=np.int64))
+    n_arr = np.atleast_1d(np.asarray(n, dtype=np.int64))
+    lo_e = np.empty(k_arr.shape, dtype=float)
+    hi_e = np.empty(k_arr.shape, dtype=float)
+    for i in np.ndindex(k_arr.shape):
+        ki, ni = int(k_arr[i]), int(n_arr[i])
+        if ni <= 0:
+            lo_e[i] = hi_e[i] = np.nan
+            continue
+        p_hat = ki / ni
+        ci = binomtest(ki, ni).proportion_ci(
+            confidence_level=CONFIDENCE_LEVEL,
+            method='exact',
+        )
+        lo_e[i] = (p_hat - ci.low) * 100
+        hi_e[i] = (ci.high - p_hat) * 100
+    if lo_e.size == 1:
+        return float(lo_e.flat[0]), float(hi_e.flat[0])
+    return lo_e, hi_e
+
+
+def sue_ratio_point_and_errors_percent(
+    W: np.ndarray,
+    Z: np.ndarray,
+    *,
+    n_resamples: int = 3999,
+    rng: np.random.Generator | int | None = None,
+) -> tuple[float, float, float]:
+    """
+    Point estimate y_hat = 100 * sum(W) / sum(Z) and asymmetric errors
+    (lower, upper) in percentage points for matplotlib errorbar.
+
+    Uses a percentile bootstrap on the same ratio with paired resampling of
+    simulation indices. Rows with invalid pairs are omitted.
+    """
+    rng = np.random.default_rng(rng)
+    W = np.asarray(W, dtype=float)
+    Z = np.asarray(Z, dtype=float)
+    valid = np.isfinite(W) & np.isfinite(Z)
+    Wv = W[valid]
+    Zv = Z[valid]
+    if Wv.size < 2:
+        return np.nan, np.nan, np.nan
+    den = np.sum(Zv)
+    if den == 0 or not np.isfinite(den):
+        return np.nan, np.nan, np.nan
+    point = float(np.sum(Wv) / den * 100)
+    n = Wv.size
+    idx = rng.integers(0, n, size=(n_resamples, n))
+    Wb = Wv[idx]
+    Zb = Zv[idx]
+    sum_w = np.sum(Wb, axis=1)
+    sum_z = np.sum(Zb, axis=1)
+    ok = np.isfinite(sum_w) & np.isfinite(sum_z) & (sum_z != 0)
+    ratios = np.full(n_resamples, np.nan, dtype=float)
+    ratios[ok] = (sum_w[ok] / sum_z[ok]) * 100
+    ratios = ratios[np.isfinite(ratios)]
+    if ratios.size < max(50, n_resamples // 20):
+        return point, np.nan, np.nan
+    alpha = (1.0 - CONFIDENCE_LEVEL) / 2.0
+    lo, hi = np.quantile(ratios, (alpha, 1.0 - alpha))
+    return point, point - lo, hi - point
+
+
+def sue_ratio_curve_points_and_errors(
+    W_rows: np.ndarray,
+    Z_rows: np.ndarray,
+    *,
+    n_resamples: int = 3999,
+    rng: np.random.Generator | int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Point estimates and asymmetric errors along candidate-count index.
+
+    Parameters
+    ----------
+    W_rows, Z_rows : shape (n_candidate_counts, n_elections)
+        Paired per-election adjusted totals for one method (W) and baseline (Z).
+    """
+    rng = np.random.default_rng(rng)
+    W_rows = np.asarray(W_rows, dtype=float)
+    Z_rows = np.asarray(Z_rows, dtype=float)
+    n_j = W_rows.shape[0]
+    y = np.empty(n_j)
+    lo_e = np.empty(n_j)
+    hi_e = np.empty(n_j)
+    for j in range(n_j):
+        pt, le, ue = sue_ratio_point_and_errors_percent(
+            W_rows[j],
+            Z_rows[j],
+            n_resamples=n_resamples,
+            rng=rng,
+        )
+        y[j] = pt
+        lo_e[j] = le
+        hi_e[j] = ue
+    return y, lo_e, hi_e

--- a/examples/weber_1977_effectiveness_table.py
+++ b/examples/weber_1977_effectiveness_table.py
@@ -22,7 +22,6 @@ Typical result with n_elections = 100_000:
 # TODO: Standard is consistently ~1% high, while Borda is very accurate
 # TODO: Best Vote-for-or-against-k is not implemented yet
 import time
-from collections import Counter
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +32,8 @@ from elsim.methods import approval, borda, fptp, utility_winner
 from elsim.strategies import honest_rankings, vote_for_k
 from weber_1977_expressions import eff_borda, eff_standard, eff_vote_for_half
 
+from plot_uncertainty import sue_ratio_curve_points_and_errors
+
 n_elections = 2_000  # Roughly 60 seconds on a 2019 6-core i7-9750H
 n_voters = 1_000
 n_cands_list = (2, 3, 4, 5, 6, 10, 255)
@@ -42,27 +43,32 @@ ranked_methods = {'Standard': fptp, 'Borda': borda}
 rated_methods = {'Vote-for-half': lambda utilities, tiebreaker:
                  approval(vote_for_k(utilities, 'half'), tiebreaker)}
 
-utility_sums = {key: Counter() for key in (ranked_methods.keys() |
-                                           rated_methods.keys() | {'UW'})}
+idx = {nc: i for i, nc in enumerate(n_cands_list)}
+nc_ct = len(n_cands_list)
+method_keys = list(ranked_methods.keys()) + list(rated_methods.keys())
+W_elec = {m: np.zeros((nc_ct, n_elections)) for m in method_keys}
+Z_uw = np.zeros((nc_ct, n_elections))
 
 start_time = time.monotonic()
 
 for iteration in range(n_elections):
     for n_cands in n_cands_list:
+        j = idx[n_cands]
         utilities = random_utilities(n_voters, n_cands)
 
-        # Find the social utility winner and accumulate utilities
         UW = utility_winner(utilities)
-        utility_sums['UW'][n_cands] += utilities.sum(axis=0)[UW]
+        Z_uw[j, iteration] = utilities.sum(axis=0)[UW] - n_voters / 2
 
         for name, method in rated_methods.items():
             winner = method(utilities, tiebreaker='random')
-            utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+            W_elec[name][j, iteration] = (
+                utilities.sum(axis=0)[winner] - n_voters / 2)
 
         rankings = honest_rankings(utilities)
         for name, method in ranked_methods.items():
             winner = method(rankings, tiebreaker='random')
-            utility_sums[name][n_cands] += utilities.sum(axis=0)[winner]
+            W_elec[name][j, iteration] = (
+                utilities.sum(axis=0)[winner] - n_voters / 2)
 
 elapsed_time = time.monotonic() - start_time
 print('Elapsed:', time.strftime("%H:%M:%S", time.gmtime(elapsed_time)), '\n')
@@ -79,19 +85,28 @@ plt.gca().set_prop_cycle(None)
 
 table = {}
 
-# Calculate Social Utility Efficiency from summed utilities
-x_uw, y_uw = zip(*sorted(utility_sums['UW'].items()))
-average_utility = n_voters * n_elections / 2
+rng = np.random.default_rng(0)
+xp = list(n_cands_list)
+
 for method in ('Standard', 'Vote-for-half', 'Borda'):
-    x, y = zip(*sorted(utility_sums[method].items()))
-    SUE = (np.array(y) - average_utility)/(np.array(y_uw) - average_utility)
-    plt.plot(x, SUE*100, '-', label=method)
-    table.update({method: SUE*100})
+    y, el, eh = sue_ratio_curve_points_and_errors(
+        W_elec[method], Z_uw, rng=rng)
+    plt.errorbar(xp, y, yerr=[el, eh], fmt='-', label=method)
+    table.update({method: y})
 
 print(tabulate(table, 'keys', showindex=n_cands_list,
                tablefmt="pipe", floatfmt='.2f'))
 
 plt.plot([], [], 'k:', lw=0.8, label='Weber')  # Dummy plot for label
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% percentile bootstrap CI for the plotted '
+    'SUE ratio (paired election resampling).',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/weber_1977_verify_vote_for_k.py
+++ b/examples/weber_1977_verify_vote_for_k.py
@@ -40,7 +40,7 @@ Typical results with 100k voters, 100k elections:
 |  9 | 51.8 |  68.5 |  77.8 |  82.0 |   82.0 |
 | 10 | 49.7 |  66.4 |  75.9 |  81.5 |   83.0 |
 """
-from collections import Counter, defaultdict
+from collections import defaultdict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -52,6 +52,8 @@ from elsim.methods import approval, fptp, utility_winner
 from elsim.strategies import honest_rankings, vote_for_k
 from weber_1977_expressions import (eff_standard, eff_vote_for_half,
                                     eff_vote_for_k)
+
+from plot_uncertainty import sue_ratio_curve_points_and_errors
 
 n_elections = 10_000  # Roughly 60 seconds on a 2019 6-core i7-9750H
 n_voters = 1_000
@@ -73,8 +75,9 @@ rated_methods = {'Vote-for-1': lambda utilities, tiebreaker:
                  approval(vote_for_k(utilities, -1), tiebreaker),
                  }
 
-utility_sums = {key: Counter() for key in (
-    ranked_methods.keys() | rated_methods.keys() | {'UW'})}
+method_keys = ['UW'] + list(ranked_methods.keys()) + list(rated_methods.keys())
+idx = {int(nc): i for i, nc in enumerate(n_cands_list)}
+nc_ct = len(n_cands_list)
 
 
 def simulate_election():
@@ -107,10 +110,19 @@ print(f'Doing {n_elections:,} elections (tasks), {n_voters:,} voters, '
 results = Parallel(n_jobs=-3, verbose=5)(delayed(simulate_election)()
                                          for i in range(n_elections))
 
-for result in results:
-    for method, d in result.items():
-        for n_cands, value in d.items():
-            utility_sums[method][n_cands] += value
+W_elec = {
+    m: np.full((nc_ct, n_elections), np.nan, dtype=float)
+    for m in method_keys
+}
+
+for ei, res in enumerate(results):
+    for m in method_keys:
+        if m not in res:
+            continue
+        for nc, value in res[m].items():
+            j = idx[int(nc)]
+            if np.isfinite(value):
+                W_elec[m][j, ei] = value - n_voters / 2
 
 plt.figure(f'Effectiveness, {n_voters} voters, {n_elections} elections')
 plt.title('The Effectiveness of Several Voting Systems')
@@ -130,20 +142,29 @@ plt.gca().set_prop_cycle(None)
 
 table = {}
 
-# Calculate Social Utility Efficiency from summed utilities
-x_uw, y_uw = zip(*sorted(utility_sums['UW'].items()))
-average_utility = n_voters * n_elections / 2
+rng = np.random.default_rng(0)
+xp = [int(x) for x in n_cands_list]
+
 for method in ('Standard', 'Vote-for-1', 'Vote-for-2', 'Vote-for-3',
                'Vote-for-4', 'Vote-for-half', 'Vote-for-(n-1)'):
-    x, y = zip(*sorted(utility_sums[method].items()))
-    SUE = (np.array(y) - average_utility)/(np.array(y_uw) - average_utility)
-    plt.plot(x, SUE*100, '-', label=method)
-    table.update({method.split('-')[-1]: SUE*100})
+    y, el, eh = sue_ratio_curve_points_and_errors(
+        W_elec[method], W_elec['UW'], rng=rng)
+    plt.errorbar(xp, y, yerr=[el, eh], fmt='-', label=method)
+    table.update({method.split('-')[-1]: y})
 
 print(tabulate(table, 'keys', showindex=[str(x) for x in n_cands_list],
                tablefmt="pipe", floatfmt='.1f'))
 
 plt.plot([], [], 'k:', lw=0.8, label='Weber')  # Dummy plot for label
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% percentile bootstrap CI for the plotted '
+    'SUE ratio (paired task resampling).',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')

--- a/examples/wikipedia_condorcet_paradox_likelihood.py
+++ b/examples/wikipedia_condorcet_paradox_likelihood.py
@@ -30,6 +30,8 @@ from tabulate import tabulate
 from elsim.elections import impartial_culture
 from elsim.methods import condorcet
 
+from plot_uncertainty import binomial_proportion_ci_errors_percent
+
 # Number of voters vs percent of elections with Condorcet paradox.
 WP_table = {3:   5.556,
             101: 8.690,
@@ -74,9 +76,21 @@ x, y = zip(*WP_table.items())
 plt.plot(x, y, label='WP')
 
 x, y = zip(*sorted(condorcet_paradox_counts.items()))
-CP = np.asarray(y) / n_elections  # Likelihood of paradox
-plt.plot(x, CP*100, '-', label='Simulation')
+k = np.asarray(y)
+CP = k / n_elections  # Likelihood of paradox
+el, eh = binomial_proportion_ci_errors_percent(k, n_elections)
+plt.errorbar(x, CP * 100, yerr=[el, eh], fmt='-', label='Simulation',
+             capsize=2, elinewidth=0.8)
 
+plt.figtext(
+    0.99,
+    0.01,
+    'Simulation error bars: 95% exact (Clopper–Pearson) CI for paradox rate '
+    f'(binomial; {n_elections:,} elections per point)',
+    fontsize=7,
+    ha='right',
+    va='bottom',
+)
 plt.legend()
 plt.grid(True, color='0.7', linestyle='-', which='major', axis='both')
 plt.grid(True, color='0.9', linestyle='-', which='minor', axis='both')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #13](https://github.com/endolith/elsim/issues/13) by documenting uncertainty explicitly on the plots that estimate proportions or ratios from Monte Carlo simulation.

### Accuracy relative to #13 / #14

- **Issue #13** correctly warns that SD, standard error, and CI are different quantities; anything plotted should be labeled. **PR #14’s direction** (explicit **95% confidence intervals** for binomial counts rather than a vague “variance” bar) matches standard practice for yes/no simulation outcomes.
- **Binary / count plots** (Condorcet efficiency conditional on a CW existing, Condorcet paradox rate, Niemi comparison): **two-sided exact (Clopper–Pearson) intervals** from `scipy.stats.binomtest(...).proportion_ci(method='exact')`, i.e. the inverse binomial test. This is an accepted frequentist CI for a binomial proportion with fixed trial count per point.
- **Social utility efficiency** is *not* binomial; it is implemented here as the **ratio of sums** actually accumulated in each script: \(\hat\theta=\sum_i W_i/\sum_i Z_i\) with paired \((W_i,Z_i)\) per simulation draw (definitions of \(W,Z\) match each figure: random-society baseline, spatial-model \(A/B\), etc.). Uncertainty uses a **paired percentile bootstrap** on that same ratio statistic—appropriate for the plug-in estimator being displayed.

Shared helpers and rationale live in `examples/plot_uncertainty.py`.

### Examples updated

Plotted examples that expose a scalar estimate per \(x\)-value now carry asymmetric vertical intervals:

- Merrill CE / Wikipedia paradox / Niemi: binomial CIs  
- Merrill Fig 3 & 4 (classic + updated), Weber effectiveness tables: bootstrap CIs for SUE  

Histogram-style scripts (e.g. `distributions_by_*`, Tomlinson figures, Merrill Fig 2a–2b scatter) are unchanged—density/scatter visuals do not use the same single-point CI semantics.

### Tests

`pytest` (191 tests) passes locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ede9df45-77da-4d61-af2e-90f015541dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ede9df45-77da-4d61-af2e-90f015541dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

