### PR TITLE
feat(studies): add approval_at_optimal rated-method helper (split 2/3 of #56)

### DIFF
--- a/elsim/studies/__init__.py
+++ b/elsim/studies/__init__.py
@@ -13,7 +13,11 @@ The ``elections`` / ``strategies`` / ``methods`` modules remain the core model;
 """
 
 from .backends import JoblibBackend, SerialBackend
-from .condorcet_metrics import merrill_1984_comparison_methods, tally_condorcet_agreement
+from .condorcet_metrics import (
+    approval_at_optimal,
+    merrill_1984_comparison_methods,
+    tally_condorcet_agreement,
+)
 from .parameters import expand_product, expand_rows, expand_zip
 from .runner import merge_counters, run_batched
 from .social_utility import (
@@ -31,6 +35,7 @@ __all__ = [
     "merge_counters",
     "run_batched",
     "merrill_1984_comparison_methods",
+    "approval_at_optimal",
     "tally_condorcet_agreement",
     "spatial_random_reference_utility_updates",
     "random_society_utility_updates",

--- a/elsim/studies/condorcet_metrics.py
+++ b/elsim/studies/condorcet_metrics.py
@@ -19,7 +19,14 @@ RankedMethod = Callable[..., Optional[int]]
 RatedMethod = Callable[..., Optional[int]]
 
 
-def _approval_at_optimal(utilities: np.ndarray, tiebreaker: str) -> Optional[int]:  # noqa: UP045
+def approval_at_optimal(utilities: np.ndarray, tiebreaker: str = "random") -> Optional[int]:  # noqa: UP045
+    """
+    Rated-method helper: build an optimal approval ballot, then apply :func:`elsim.methods.approval`.
+
+    Intended for use in a ``rated_methods`` mapping passed to
+    :func:`tally_condorcet_agreement` or the spatial sweep helpers, so scripts
+    stay declarative without repeating lambdas.
+    """
     return approval(approval_optimal(utilities), tiebreaker)
 
 
@@ -44,7 +51,7 @@ def merrill_1984_comparison_methods() -> tuple[dict[str, RankedMethod], dict[str
     }
     rated_methods: dict[str, RatedMethod] = {
         "SU max": utility_winner,
-        "Approval": _approval_at_optimal,
+        "Approval": approval_at_optimal,
     }
     return ranked_methods, rated_methods
 
@@ -76,7 +83,7 @@ def tally_condorcet_agreement(
     Returns
     -------
     collections.Counter
-        Includes key ``\"CW\"`` when a Condorcet winner exists, plus one key per
+        Includes key ``"CW"`` when a Condorcet winner exists, plus one key per
         supplied method name when that method's winner matches the Condorcet
         winner.
     """


### PR DESCRIPTION
Split 2 of 3 from #56, stacked on #52 (base: `cursor/issue-10-simulation-api-44e5`), sibling of #81.

**Problem:** `rated_methods` mappings repeat the same lambda (`approval(approval_optimal(utilities), tiebreaker)`) in every Merrill-style script.

**Approach:** promote the private `_approval_at_optimal` wrapper to public `approval_at_optimal(utilities, tiebreaker="random")`, add a docstring, export it from `elsim.studies`, and switch `merrill_1984_comparison_methods` to use it. Existing tests cover it through `merrill_1984_comparison_methods`.

**Commits:**
- `b4f56e2` feat(studies): promote approval_at_optimal to a public rated-method helper

Also drops a stray backslash in a `condorcet_metrics` docstring while in the file.

— [Skales](https://github.com/skalesapp/skales)