### PR TITLE
feat(studies): use approval_at_optimal in Merrill tables 1/2/4 (split 3/3 of #56)

### DIFF
--- a/elsim/studies/__init__.py
+++ b/elsim/studies/__init__.py
@@ -13,7 +13,11 @@ The ``elections`` / ``strategies`` / ``methods`` modules remain the core model;
 """
 
 from .backends import JoblibBackend, SerialBackend
-from .condorcet_metrics import merrill_1984_comparison_methods, tally_condorcet_agreement
+from .condorcet_metrics import (
+    approval_at_optimal,
+    merrill_1984_comparison_methods,
+    tally_condorcet_agreement,
+)
 from .parameters import expand_product, expand_rows, expand_zip
 from .runner import merge_counters, run_batched
 from .social_utility import (
@@ -31,6 +35,7 @@ __all__ = [
     "merge_counters",
     "run_batched",
     "merrill_1984_comparison_methods",
+    "approval_at_optimal",
     "tally_condorcet_agreement",
     "spatial_random_reference_utility_updates",
     "random_society_utility_updates",

--- a/elsim/studies/condorcet_metrics.py
+++ b/elsim/studies/condorcet_metrics.py
@@ -19,7 +19,14 @@ RankedMethod = Callable[..., Optional[int]]
 RatedMethod = Callable[..., Optional[int]]
 
 
-def _approval_at_optimal(utilities: np.ndarray, tiebreaker: str) -> Optional[int]:  # noqa: UP045
+def approval_at_optimal(utilities: np.ndarray, tiebreaker: str = "random") -> Optional[int]:  # noqa: UP045
+    """
+    Rated-method helper: build an optimal approval ballot, then apply :func:`elsim.methods.approval`.
+
+    Intended for use in a ``rated_methods`` mapping passed to
+    :func:`tally_condorcet_agreement` or the spatial sweep helpers, so scripts
+    stay declarative without repeating lambdas.
+    """
     return approval(approval_optimal(utilities), tiebreaker)
 
 
@@ -44,7 +51,7 @@ def merrill_1984_comparison_methods() -> tuple[dict[str, RankedMethod], dict[str
     }
     rated_methods: dict[str, RatedMethod] = {
         "SU max": utility_winner,
-        "Approval": _approval_at_optimal,
+        "Approval": approval_at_optimal,
     }
     return ranked_methods, rated_methods
 
@@ -76,7 +83,7 @@ def tally_condorcet_agreement(
     Returns
     -------
     collections.Counter
-        Includes key ``\"CW\"`` when a Condorcet winner exists, plus one key per
+        Includes key ``"CW"`` when a Condorcet winner exists, plus one key per
         supplied method name when that method's winner matches the Condorcet
         winner.
     """

--- a/examples/merrill_1984_table_1_fig_1.py
+++ b/examples/merrill_1984_table_1_fig_1.py
@@ -32,14 +32,19 @@ import numpy as np
 from tabulate import tabulate
 
 from elsim.elections import random_utilities
+from elsim.methods import black, borda, coombs, fptp, irv, runoff, utility_winner
 from elsim.strategies import honest_rankings
-from elsim.studies import merrill_1984_comparison_methods, tally_condorcet_agreement
+from elsim.studies import approval_at_optimal, tally_condorcet_agreement
 
 n_elections = 10_000  # Roughly 15 seconds on a 2019 6-core i7-9750H
 n_voters = 25
 n_cands_list = (2, 3, 4, 5, 7, 10)
 
-ranked_methods, rated_methods = merrill_1984_comparison_methods()
+ranked_methods = {'Plurality': fptp, 'Runoff': runoff, 'Hare': irv,
+                  'Borda': borda, 'Coombs': coombs, 'Black': black}
+
+rated_methods = {'SU max': utility_winner,
+                 'Approval': approval_at_optimal}
 
 condorcet_winner_count = {key: Counter() for key in (
     ranked_methods.keys() | rated_methods.keys() | {'CW'})}

--- a/examples/merrill_1984_table_2.py
+++ b/examples/merrill_1984_table_2.py
@@ -38,14 +38,19 @@ import numpy as np
 from tabulate import tabulate
 
 from elsim.elections import normal_electorate, normed_dist_utilities
+from elsim.methods import black, borda, coombs, fptp, irv, runoff, utility_winner
 from elsim.strategies import honest_rankings
-from elsim.studies import expand_rows, merrill_1984_comparison_methods, tally_condorcet_agreement
+from elsim.studies import approval_at_optimal, expand_rows, tally_condorcet_agreement
 
 n_elections = 10_000  # Roughly 60 seconds on a 2019 6-core i7-9750H
 n_voters = 201
 n_cands = 5
 
-ranked_methods, rated_methods = merrill_1984_comparison_methods()
+ranked_methods = {'Plurality': fptp, 'Runoff': runoff, 'Hare': irv,
+                  'Borda': borda, 'Coombs': coombs, 'Black': black}
+
+rated_methods = {'SU max': utility_winner,
+                 'Approval': approval_at_optimal}
 
 #             disp, corr, D
 condition_rows = ((1.0, 0.5, 2),

--- a/examples/merrill_1984_table_4.py
+++ b/examples/merrill_1984_table_4.py
@@ -36,10 +36,11 @@ import numpy as np
 from tabulate import tabulate
 
 from elsim.elections import normal_electorate, normed_dist_utilities
+from elsim.methods import black, borda, coombs, fptp, irv, runoff, utility_winner
 from elsim.strategies import honest_rankings
 from elsim.studies import (
+    approval_at_optimal,
     expand_rows,
-    merrill_1984_comparison_methods,
     spatial_random_reference_utility_updates,
 )
 
@@ -47,7 +48,11 @@ n_elections = 10_000  # Roughly 60 seconds on a 2019 6-core i7-9750H
 n_voters = 201
 n_cands = 5
 
-ranked_methods, rated_methods = merrill_1984_comparison_methods()
+ranked_methods = {'Plurality': fptp, 'Runoff': runoff, 'Hare': irv,
+                  'Borda': borda, 'Coombs': coombs, 'Black': black}
+
+rated_methods = {'SU max': utility_winner,
+                 'Approval': approval_at_optimal}
 
 #             disp, corr, D
 condition_rows = ((1.0, 0.5, 2),


### PR DESCRIPTION
Split 3 of 3 from #56, per the plan in #80. Stacked on #82 (base: `cursor/issue-10-simulation-api-44e5`), sibling of #81 and #82.

**Problem:** `merrill_1984_table_1_fig_1.py`, `merrill_1984_table_2.py`, and `merrill_1984_table_4.py` still build `ranked_methods`/`rated_methods` from the shared `merrill_1984_comparison_methods()` helper, which hardcodes the Merrill method set.

**Approach:** define the method dicts locally in each table script, importing the methods directly and using the new public `approval_at_optimal` helper for the Approval entry — the same inline pattern already used by the `_updated` fig scripts (2c/2d, 4a/4b) and table 3. This removes the last hardcoded-Merrill dependency from the table scripts.

`merrill_1984_comparison_methods` stays in `condorcet_metrics.py` because the non-updated `fig_2c_2d.py` and `fig_4a_4b.py` still use it.

**Commits:**
- `f8f4f8d` feat(studies): define Merrill tables 1/2/4 methods locally with approval_at_optimal

— [Skales](https://github.com/skalesapp/skales)